### PR TITLE
fix(security): add auth gate for critical control APIs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,6 @@ INFLUXDB_DATABASE=smarthome
 
 # Security
 SECRET_KEY=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
+SMARTHOME_ADMIN_API_KEY=
+# Optional: erlaubt lokale Aufrufe ohne API-Key (default: true)
+SMARTHOME_ALLOW_LOOPBACK_WITHOUT_KEY=true


### PR DESCRIPTION
## Summary
Implements a server-side authentication gate for critical control endpoints and adds client-side API-key header injection support.

### Backend
- Adds `before_request` auth gate in `web_manager` for control routes.
- Protects critical endpoints (admin/service restart, PLC connect/disconnect, ADS route write/test, camera/PTZ control, variable write, etc.).
- Accepts API key from:
  - `X-API-Key`
  - `Authorization: Bearer <key>`
  - query `api_key`
- Key source:
  - `SMARTHOME_ADMIN_API_KEY` (preferred)
  - `ADMIN_API_KEY` (fallback)
- Compatibility mode:
  - Loopback without key can be allowed via `SMARTHOME_ALLOW_LOOPBACK_WITHOUT_KEY=true`.

### Frontend
- Adds fetch wrapper to inject `X-API-Key` automatically from:
  - `localStorage.smarthome_admin_api_key`
  - `localStorage.admin_api_key`

### Config
- Adds new env examples in `.env.example`.

## Validation
- `python3 -m py_compile modules/gateway/web_manager.py start_web_hmi.py module_manager.py import_tpy.py`
- `python3 -m compileall -q modules`
- `venv/bin/python -m pytest -q test_web_manager_fix.py test_logging_system.py` (8 passed)

Addresses #2
