### PR TITLE
fix(security): secrets/config hardening baseline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # SmartHome Edge OS v5.0 Environment Configuration
 
 # Sentry Error Tracking
-SENTRY_DSN="https://df84f77f4768c3b6ed8224089e930008@o4510659601891328.ingest.de.sentry.io/4510659620831312"
+SENTRY_DSN=""
 ENVIRONMENT=development  # production, staging, development
 
 # Application
@@ -19,7 +19,7 @@ INFLUXDB_PORT=8086
 INFLUXDB_DATABASE=smarthome
 
 # Security
-SECRET_KEY=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
+SECRET_KEY=change-me-to-a-random-secret
 SMARTHOME_ADMIN_API_KEY=
 # Optional: erlaubt lokale Aufrufe ohne API-Key (default: true)
 SMARTHOME_ALLOW_LOOPBACK_WITHOUT_KEY=true

--- a/docs/FIX_v5.1.0_SUMMARY.md
+++ b/docs/FIX_v5.1.0_SUMMARY.md
@@ -135,7 +135,7 @@ $ python -m py_compile modules/gateway/plc_config_manager.py
 
 ```bash
 # .env Datei (bereits vorhanden)
-SENTRY_DSN="https://df84f77f4768c3b6ed8224089e930008@o4510659601891328.ingest.de.sentry.io/4510659620831312"
+SENTRY_DSN=""
 ENVIRONMENT=development
 ```
 

--- a/docs/LOGGING_GUIDE.md
+++ b/docs/LOGGING_GUIDE.md
@@ -19,7 +19,7 @@ Das System verwendet ein **Multi-Layer Logging-System**:
 Die `.env.example` enthält bereits einen konfigurierten Sentry DSN:
 
 ```bash
-SENTRY_DSN="https://df84f77f4768c3b6ed8224089e930008@o4510659601891328.ingest.de.sentry.io/4510659620831312"
+SENTRY_DSN=""
 ENVIRONMENT=development
 ```
 


### PR DESCRIPTION
## Summary
Implements the first concrete hardening slice for issue #12.

### Changes
- Removes sensitive-looking values from tracked examples/docs:
  - `.env.example`: `SENTRY_DSN` now empty, `SECRET_KEY` now placeholder.
  - `docs/LOGGING_GUIDE.md`: no real DSN example anymore.
  - `docs/FIX_v5.1.0_SUMMARY.md`: no real DSN example anymore.
- Replaces hardcoded Flask secret in backend:
  - `modules/gateway/web_manager.py` now uses `SECRET_KEY` from environment.
  - If missing, generates ephemeral key via `secrets.token_hex(32)` and logs warning.

## Validation
- `python3 -m py_compile modules/gateway/web_manager.py start_web_hmi.py module_manager.py import_tpy.py`
- `python3 -m compileall -q modules`
- `node --check web/static/js/app.js`
- `venv/bin/python -m pytest -q test_web_manager_fix.py test_logging_system.py` (8 passed)

Addresses #12
