### PR TITLE
fix(security): rate-limit critical control endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,7 @@ SECRET_KEY=change-me-to-a-random-secret
 SMARTHOME_ADMIN_API_KEY=
 # Optional: erlaubt lokale Aufrufe ohne API-Key (default: true)
 SMARTHOME_ALLOW_LOOPBACK_WITHOUT_KEY=true
+# Rate-Limit auf kritischen Control-Endpoints (pro IP+Path)
+SMARTHOME_CONTROL_RATE_LIMIT_WINDOW_SECONDS=60
+SMARTHOME_CONTROL_RATE_LIMIT_MAX_REQUESTS=120
+SMARTHOME_CONTROL_RATE_LIMIT_EXEMPT_LOOPBACK=true


### PR DESCRIPTION
## Summary
Adds server-side rate limiting for critical control APIs to reduce abuse and burst overload risk.

### Changes
- Adds in-memory rate limiter in `modules/gateway/web_manager.py`.
- Applies limiter in `before_request` for protected control endpoints.
- Returns `429` with `Retry-After` when exceeded.
- New env knobs in `.env.example`:
  - `SMARTHOME_CONTROL_RATE_LIMIT_WINDOW_SECONDS` (default `60`)
  - `SMARTHOME_CONTROL_RATE_LIMIT_MAX_REQUESTS` (default `120`)
  - `SMARTHOME_CONTROL_RATE_LIMIT_EXEMPT_LOOPBACK` (default `true`)

## Validation
- `python3 -m py_compile modules/gateway/web_manager.py start_web_hmi.py module_manager.py import_tpy.py`
- `python3 -m compileall -q modules`
- `node --check web/static/js/app.js`
- `venv/bin/python -m pytest -q test_web_manager_fix.py test_logging_system.py` (8 passed)

Addresses #19
