### PR TITLE
feat(admin): filter restart events in system logs

### DIFF
--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -4765,6 +4765,9 @@ class SmartHomeApp {
 
     async loadAdminPage() {
         console.log('👑 Lade Admin...');
+        if (!this._adminLogFilter) {
+            this._adminLogFilter = 'all';
+        }
 
         // ⭐ v5.1.1: Lade Widgets für diese Page
         await this.loadAndRenderWidgets('admin');
@@ -4782,6 +4785,7 @@ class SmartHomeApp {
         const clearLogsBtn = document.getElementById('clear-logs-btn');
         const restartServiceBtn = document.getElementById('restart-service-btn');
         const restartDaemonBtn = document.getElementById('restart-daemon-btn');
+        const logsFilterSelect = document.getElementById('logs-filter-select');
 
         if (addPlcBtn) {
             addPlcBtn.addEventListener('click', () => this.addPLC());
@@ -4793,6 +4797,14 @@ class SmartHomeApp {
 
         if (refreshLogsBtn) {
             refreshLogsBtn.addEventListener('click', () => this.loadLogs());
+        }
+
+        if (logsFilterSelect) {
+            logsFilterSelect.value = this._adminLogFilter || 'all';
+            logsFilterSelect.addEventListener('change', () => {
+                this._adminLogFilter = logsFilterSelect.value || 'all';
+                this.loadLogs();
+            });
         }
 
         if (clearLogsBtn) {
@@ -4811,7 +4823,8 @@ class SmartHomeApp {
         console.log('📋 Lade System-Logs...');
 
         try {
-            const response = await fetch('/api/admin/logs?limit=50');
+            const filter = this._adminLogFilter || 'all';
+            const response = await fetch(`/api/admin/logs?limit=50&filter=${encodeURIComponent(filter)}`);
             if (!response.ok) throw new Error('Logs konnten nicht geladen werden');
 
             const logs = await response.json();

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -957,7 +957,11 @@
             <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6 mb-6">
                 <div class="flex items-center justify-between mb-4">
                     <h2 class="text-lg font-semibold text-gray-900 dark:text-white">System-Logs</h2>
-                    <div class="flex space-x-2">
+                    <div class="flex items-center space-x-2">
+                        <select id="logs-filter-select" class="px-2 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-900 text-gray-700 dark:text-gray-200">
+                            <option value="all">Alle</option>
+                            <option value="restart">Restart</option>
+                        </select>
                         <button id="refresh-logs-btn" class="px-3 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600">
                             <i data-lucide="refresh-cw" class="w-4 h-4 inline mr-1"></i> Aktualisieren
                         </button>
@@ -1016,12 +1020,17 @@
                         </div>
                     </div>
 
-                    <!-- Restart-Button -->
-                    <button id="restart-service-btn" class="w-full px-4 py-3 bg-red-500 text-white rounded-lg hover:bg-red-600 font-semibold">
-                        <i data-lucide="rotate-cw" class="w-5 h-5 inline mr-2"></i> Service neu starten
-                    </button>
+                    <!-- Restart-Buttons -->
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+                        <button id="restart-service-btn" class="w-full px-4 py-3 bg-amber-500 text-white rounded-lg hover:bg-amber-600 font-semibold">
+                            <i data-lucide="rotate-cw" class="w-5 h-5 inline mr-2"></i> App neu starten
+                        </button>
+                        <button id="restart-daemon-btn" class="w-full px-4 py-3 bg-red-500 text-white rounded-lg hover:bg-red-600 font-semibold">
+                            <i data-lucide="server" class="w-5 h-5 inline mr-2"></i> Dienst neu starten
+                        </button>
+                    </div>
                     <p class="text-xs text-gray-500 dark:text-gray-400 text-center">
-                        ⚠️ Der Service wird in 2 Sekunden neu gestartet. Die Seite lädt automatisch neu.
+                        App-Neustart: nur Prozess. Dienst-Neustart: via <span class="font-mono">scripts/web_server_ctl.sh restart</span>.
                     </p>
                 </div>
 


### PR DESCRIPTION
## Summary
Adds a dedicated restart-event filter to Admin system logs.

### Backend
- `/api/admin/logs` now accepts `filter` query param:
  - `all` (default)
  - `restart`
- For `restart`, server filters messages by restart-related keywords (`restart`, `neustart`).

### Frontend
- Admin Logs panel now includes a filter dropdown:
  - `Alle`
  - `Restart`
- Selected filter is applied when loading logs and on refresh.

## Validation
- `python3 -m py_compile modules/gateway/web_manager.py`
- `node --check web/static/js/app.js`
- `venv/bin/python -m pytest -q test_web_manager_fix.py test_logging_system.py` (`8 passed`)

Addresses #1
