### PR TITLE
ci(security): add secret scanning guardrails (gitleaks)

### DIFF
--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -1,0 +1,25 @@
+name: Secret Scan
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: detect --source . --verbose --config .gitleaks.toml

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,14 @@
+[extend]
+useDefault = true
+
+[[rules]]
+id = "sentry-dsn"
+description = "Sentry DSN"
+regex = '''SENTRY_DSN\s*=\s*["']?https://[A-Za-z0-9._%-]+@o[0-9]+\.ingest\.[A-Za-z0-9.-]+/[0-9]+'''
+tags = ["key", "sentry", "secret"]
+
+[[rules]]
+id = "sentry-token-prefix"
+description = "Sentry token prefix"
+regex = '''sntrys_[A-Za-z0-9]{20,}|sntryu_[A-Za-z0-9]{20,}|sntryp_[A-Za-z0-9]{20,}'''
+tags = ["key", "sentry", "secret"]


### PR DESCRIPTION
## Summary
Adds secret scanning guardrails to prevent accidental publication of credentials/tokens.

### Added
- `.github/workflows/secrets-scan.yml`
  - runs on pull requests and pushes to `main`
  - uses `gitleaks/gitleaks-action`
- `.gitleaks.toml`
  - extends default gitleaks rules
  - adds custom Sentry-focused rules:
    - `SENTRY_DSN=...` pattern
    - sentry token prefixes (`sntrys_`, `sntryu_`, `sntryp_`)

## Why
A previously published Sentry DSN existed in historical commits.
This workflow blocks similar leaks in future changes.

Related: #12, #39
