### PR TITLE
fix(stream): avoid ffmpeg stderr pipe backlog + daemon restart hook

### DIFF
--- a/modules/gateway/stream_manager.py
+++ b/modules/gateway/stream_manager.py
@@ -195,8 +195,8 @@ class StreamManager(BaseModule):
                 # Starte FFmpeg-Prozess
                 process = subprocess.Popen(
                     cmd,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
                     stdin=subprocess.DEVNULL
                 )
 
@@ -353,7 +353,7 @@ class StreamManager(BaseModule):
                     cmd,
                     env=env,
                     stdout=subprocess.DEVNULL,
-                    stderr=subprocess.PIPE,
+                    stderr=subprocess.DEVNULL,
                     stdin=subprocess.DEVNULL
                 )
 
@@ -489,6 +489,7 @@ class StreamManager(BaseModule):
             FFmpeg-Kommando als Liste
         """
         cmd = ['ffmpeg']
+        cmd.extend(['-hide_banner', '-loglevel', 'warning'])
 
         # Hardware-Beschleunigung (Input) - nur wenn kein Scaling nötig
         if use_hw_accel and not resolution and self.hw_accel_mode == 'qsv':


### PR DESCRIPTION
## Summary
- avoid long-running ffmpeg subprocess pipe backpressure by redirecting RTSP and Ring stream stderr/stdout to DEVNULL
- add ServiceManager.schedule_ctl_restart() used by admin endpoint /api/admin/service/restart-daemon
- add ffmpeg default runtime flags (-hide_banner, -loglevel warning) for cleaner and safer process behavior

## Why
Long-running stream processes can stall when child pipes are not consumed continuously. This is a likely contributor to intermittent camera/ring stutter under prolonged viewing.

## Validation
- python3 -m py_compile modules/core/service_manager.py modules/gateway/stream_manager.py
- local pytest unavailable in this environment (pytest: command not found)

## Related
- refs #11
- refs #38