### PR TITLE
Docs: enforce placeholder-only Sentry DSN examples

### DIFF
--- a/docs/IMPLEMENTATION-ROADMAP.md
+++ b/docs/IMPLEMENTATION-ROADMAP.md
@@ -170,7 +170,7 @@ def critical_operation(self):
 #### 9.3 Environment-Config (15min)
 **Datei:** `.env.example`
 ```env
-SENTRY_DSN=https://your-sentry-dsn@sentry.io/project-id
+SENTRY_DSN=https://[your-key]@[org].ingest.sentry.io/[project-id]
 ENVIRONMENT=production  # oder development/staging
 ```
 

--- a/docs/LOGGING_GUIDE.md
+++ b/docs/LOGGING_GUIDE.md
@@ -14,16 +14,16 @@ Das System verwendet ein **Multi-Layer Logging-System**:
 
 ### 1. Sentry Konfiguration (Optional, aber empfohlen)
 
-#### Option A: Verwende bestehenden Sentry DSN (aus .env)
+#### Option A: Placeholder aus `.env.example` übernehmen
 
-Die `.env.example` enthält bereits einen konfigurierten Sentry DSN:
+Die `.env.example` enthält bewusst **keinen echten DSN**, sondern nur einen leeren Placeholder:
 
 ```bash
 SENTRY_DSN=""
 ENVIRONMENT=development
 ```
 
-Kopiere einfach `.env.example` nach `.env` (falls noch nicht geschehen):
+Kopiere `.env.example` nach `.env` (falls noch nicht geschehen) und trage den echten DSN nur lokal ein:
 
 ```bash
 cp .env.example .env
@@ -40,6 +40,8 @@ cp .env.example .env
 SENTRY_DSN="https://[your-key]@[org].ingest.sentry.io/[project-id]"
 ENVIRONMENT=production
 ```
+
+Hinweis: Keine echten DSNs/Secrets in Doku, `.env.example` oder Commits eintragen.
 
 #### Sentry deaktivieren
 

--- a/docs/SENTRY-INTEGRATION.md
+++ b/docs/SENTRY-INTEGRATION.md
@@ -25,11 +25,13 @@ Kopiere `.env.example` zu `.env` und konfiguriere:
 
 ```env
 # Sentry DSN (von sentry.io)
-SENTRY_DSN=https://your-key@o123456.ingest.sentry.io/1234567
+SENTRY_DSN=https://[your-key]@[org].ingest.sentry.io/[project-id]
 
 # Environment (production, staging, development)
 ENVIRONMENT=production
 ```
+
+Sicherheitsregel: Verwende nur Platzhalter in Dokumentation und niemals reale Secrets im Repository.
 
 ### 3. Automatische Initialisierung
 


### PR DESCRIPTION
## Summary
- clarify in `docs/LOGGING_GUIDE.md` that `.env.example` must contain placeholders only and no real DSN
- normalize DSN examples in `docs/SENTRY-INTEGRATION.md` and `docs/IMPLEMENTATION-ROADMAP.md` to redacted placeholder format
- add explicit reminder to never commit real DSN/secrets in docs or repository files

## Why
Issue #57 tracks a historical Sentry DSN exposure. This PR closes remaining repository-side doc hygiene gaps and aligns docs with `SECURITY.md`/`CONTRIBUTING.md` rules.

## Validation
- text grep check for legacy unsafe wording/patterns in updated docs

Refs #57
