### PR TITLE
Add least-privilege Docker runtime baseline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.gitignore
+.pytest_cache
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.db
+*.sqlite
+.venv/
+venv/
+node_modules/
+.env
+.env.*
+config/*.db
+config/*.log
+config/*.sqlite*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Runtime user (non-root) for least-privilege execution.
+RUN groupadd --system --gid 10001 smarthome \
+    && useradd --system --uid 10001 --gid 10001 --create-home smarthome
+
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r /app/requirements.txt
+
+COPY . /app
+
+# Writable runtime directories for config/state/stream segments.
+RUN mkdir -p /app/config /app/plc_data /app/web/static/hls \
+    && chown -R 10001:10001 /app
+
+USER 10001:10001
+
+EXPOSE 5000
+
+CMD ["python", "start_web_hmi.py"]

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Inhalt:
 - PLC Runtime (TC2/TC3) korrekt konfigurieren
 - ADS TwinCAT Routen im Web-Setup verwalten (Status/Anlegen/Test)
 - Routing-Regeln über Setup-UI bearbeiten (`config/routing.json`)
+- Docker-Hardening/Least-Privilege: `docs/DOCKER_LEAST_PRIVILEGE.md`
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: "3.9"
+
+services:
+  smarthome-web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: smarthome-web:latest
+    container_name: smarthome-web
+    user: "10001:10001"
+    restart: unless-stopped
+    ports:
+      - "5000:5000"
+    env_file:
+      - .env
+    environment:
+      - PYTHONUNBUFFERED=1
+    read_only: true
+    tmpfs:
+      - /tmp:size=64m,noexec,nosuid,nodev
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 256
+    volumes:
+      - ./config:/app/config:rw
+      - ./plc_data:/app/plc_data:rw
+      - ./web/static/hls:/app/web/static/hls:rw
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://127.0.0.1:5000/', timeout=3)\""]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s

--- a/docs/DOCKER_LEAST_PRIVILEGE.md
+++ b/docs/DOCKER_LEAST_PRIVILEGE.md
@@ -1,0 +1,24 @@
+# Docker Least-Privilege Runtime
+
+Diese Container-Definition läuft standardmäßig mit minimalen Rechten:
+
+- Non-root User: `10001:10001`
+- `read_only: true` für Root-Filesystem
+- `cap_drop: [ALL]`
+- `no-new-privileges:true`
+- begrenzte PID-Anzahl (`pids_limit: 256`)
+- explizite RW-Mounts nur für Runtime-State:
+  - `./config -> /app/config`
+  - `./plc_data -> /app/plc_data`
+  - `./web/static/hls -> /app/web/static/hls`
+
+## Start
+
+```bash
+docker compose up -d --build
+```
+
+## Hinweise
+
+- `.env` wird zur Laufzeit eingebunden (`env_file: .env`), aber nicht ins Image kopiert.
+- Für zusätzliche Hardware-/Device-Zugriffe (z. B. Bluetooth/Serial) sollten Rechte gezielt und minimal ergänzt werden, statt pauschal `privileged: true` zu verwenden.


### PR DESCRIPTION
## Summary
- add `Dockerfile` with non-root runtime user (`10001:10001`)
- add `.dockerignore` to avoid shipping local secrets/state into image context
- add `docker-compose.yml` least-privilege baseline:
  - `read_only: true`
  - `cap_drop: [ALL]`
  - `security_opt: [no-new-privileges:true]`
  - bounded `tmpfs` and `pids_limit`
  - explicit RW volumes only for required runtime state
- add operational doc `docs/DOCKER_LEAST_PRIVILEGE.md`
- link Docker hardening doc from `README.md`

## Validation
- static review of container/security settings
- note: local `docker compose config` could not be executed in this environment (`docker` binary missing)

Closes #34
