### PR TITLE
Add signed release workflow and artifact verification docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,81 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
+jobs:
+  build-and-release:
+    name: build-and-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Prepare metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME:-snapshot}"
+          if [[ -z "${TAG}" || "${TAG}" == "refs/heads/"* ]]; then
+            TAG="snapshot-${GITHUB_SHA::7}"
+          fi
+          PKG="smarthome-web-${TAG}"
+          mkdir -p dist
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "pkg=${PKG}" >> "$GITHUB_OUTPUT"
+
+      - name: Build source archives
+        shell: bash
+        run: |
+          set -euo pipefail
+          PKG="${{ steps.meta.outputs.pkg }}"
+          git archive --format=tar.gz --prefix="${PKG}/" -o "dist/${PKG}.tar.gz" HEAD
+          git archive --format=zip --prefix="${PKG}/" -o "dist/${PKG}.zip" HEAD
+
+      - name: Generate checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd dist
+          sha256sum *.tar.gz *.zip > SHA256SUMS
+
+      - name: Upload workflow artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-assets-${{ steps.meta.outputs.tag }}
+          path: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/SHA256SUMS
+          if-no-files-found: error
+
+      - name: Attest release artifacts
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/SHA256SUMS
+
+      - name: Publish GitHub release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.meta.outputs.tag }}
+          files: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/SHA256SUMS
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Inhalt:
 - ADS TwinCAT Routen im Web-Setup verwalten (Status/Anlegen/Test)
 - Routing-Regeln über Setup-UI bearbeiten (`config/routing.json`)
 - Docker-Hardening/Least-Privilege: `docs/DOCKER_LEAST_PRIVILEGE.md`
+- Release-Verifikation (Checksums + Attestation): `docs/RELEASE_VERIFICATION.md`
 
 ---
 

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -1,0 +1,46 @@
+# Release Verification
+
+Dieser Ablauf prüft vor dem Einsatz, dass ein Release-Artefakt authentisch und unverändert ist.
+
+## Voraussetzungen
+
+- `gh` (GitHub CLI) installiert und authentifiziert
+- `sha256sum` verfügbar
+
+## 1. Artefakte und Checksums herunterladen
+
+Beispiel für Tag `v1.2.3`:
+
+```bash
+gh release download v1.2.3 -D release-v1.2.3
+cd release-v1.2.3
+```
+
+## 2. Integrität via SHA256 prüfen
+
+```bash
+sha256sum -c SHA256SUMS
+```
+
+Erwartung: alle Einträge melden `OK`.
+
+## 3. Build-Provenance Attestation prüfen
+
+```bash
+gh attestation verify smarthome-web-v1.2.3.tar.gz \
+  --repo zonfacter/SmartHome_py
+```
+
+Optional auch für ZIP:
+
+```bash
+gh attestation verify smarthome-web-v1.2.3.zip \
+  --repo zonfacter/SmartHome_py
+```
+
+## 4. Nur verifizierte Artefakte deployen
+
+Deploy nur ausführen, wenn:
+
+- Checksum-Prüfung erfolgreich ist
+- Attestation-Prüfung erfolgreich ist


### PR DESCRIPTION
## Summary
- add release workflow `.github/workflows/release.yml`
  - build source archives (`.tar.gz` + `.zip`) from tagged commits
  - generate `SHA256SUMS`
  - publish assets to GitHub Release (on `v*` tags)
  - generate GitHub build provenance attestations for release artifacts
- add documented verification process in `docs/RELEASE_VERIFICATION.md`
- link release verification guide from `README.md`

## Security impact
- release artifacts can be integrity-checked via SHA256
- artifact provenance can be verified via GitHub attestations
- verification process is documented for operators

Closes #44
