### PR TITLE
Normalize timestamps to UTC ISO8601 across gateway outputs

### DIFF
--- a/modules/integrations/mqtt_integration.py
+++ b/modules/integrations/mqtt_integration.py
@@ -21,6 +21,7 @@ import time
 import json
 import os
 import logging
+from datetime import datetime, timezone
 
 
 logger = logging.getLogger(__name__)
@@ -241,9 +242,11 @@ class MqttIntegration(BaseModule):
                 return
 
         # Cache Wert
+        now = time.time()
         self.values[topic] = {
             'value': value,
-            'timestamp': time.time()
+            'timestamp': now,
+            'timestamp_utc': datetime.fromtimestamp(now, tz=timezone.utc).isoformat().replace('+00:00', 'Z')
         }
         while len(self.values) > self._max_cached_topics:
             oldest_topic = next(iter(self.values))

--- a/modules/integrations/mqtt_module.py
+++ b/modules/integrations/mqtt_module.py
@@ -21,6 +21,7 @@ import time
 import json
 import os
 import logging
+from datetime import datetime, timezone
 
 
 logger = logging.getLogger(__name__)
@@ -241,9 +242,11 @@ class MqttIntegration(BaseModule):
                 return
 
         # Cache Wert
+        now = time.time()
         self.values[topic] = {
             'value': value,
-            'timestamp': time.time()
+            'timestamp': now,
+            'timestamp_utc': datetime.fromtimestamp(now, tz=timezone.utc).isoformat().replace('+00:00', 'Z')
         }
         while len(self.values) > self._max_cached_topics:
             oldest_topic = next(iter(self.values))


### PR DESCRIPTION
## Summary
- normalize outbound timestamps in Gateway/API events by adding UTC ISO8601 fields (`*_utc`) while preserving existing epoch fields for compatibility
- add centralized UTC helper in `web_manager.py` and apply to monitor/trigger/socket payloads
- add timestamp migration fallback parser in `data_gateway.py`
  - accepts epoch numbers, numeric strings, and ISO8601 strings
  - normalizes to `(timestamp, timestamp_utc)`
- include normalized timestamps in variable update payloads and routed MQTT payloads
- include UTC timestamp in MQTT cache entries (`mqtt_integration.py` / `mqtt_module.py`)

## Compatibility / Migration
- existing `timestamp` fields remain unchanged (epoch)
- new `timestamp_utc` fields provide consistent ISO8601 UTC format
- legacy timestamp inputs are parsed via `_normalize_timestamp` fallback logic

## Validation
- `python3 -m py_compile modules/gateway/web_manager.py modules/gateway/data_gateway.py modules/integrations/mqtt_integration.py modules/integrations/mqtt_module.py`
- `venv/bin/python -m pytest -q test_web_manager_fix.py test_logging_system.py` -> `8 passed`

Closes #42
