### PR TITLE
security: API-Key Pflicht default für Control-Endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,8 +21,8 @@ INFLUXDB_DATABASE=smarthome
 # Security
 SECRET_KEY=change-me-to-a-random-secret
 SMARTHOME_ADMIN_API_KEY=
-# Optional: erlaubt lokale Aufrufe ohne API-Key (default: true)
-SMARTHOME_ALLOW_LOOPBACK_WITHOUT_KEY=true
+# Optional: erlaubt lokale Aufrufe ohne API-Key (default: false, nur fuer Dev-Fallback aktivieren)
+SMARTHOME_ALLOW_LOOPBACK_WITHOUT_KEY=false
 # Rate-Limit auf kritischen Control-Endpoints (pro IP+Path)
 SMARTHOME_CONTROL_RATE_LIMIT_WINDOW_SECONDS=60
 SMARTHOME_CONTROL_RATE_LIMIT_MAX_REQUESTS=120

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,4 @@ jobs:
           pytest -q test_api_contracts.py
           pytest -q test_backup_manager.py
           pytest -q test_integration_core_flows.py
+          pytest -q test_control_auth_security.py

--- a/modules/gateway/web_manager.py
+++ b/modules/gateway/web_manager.py
@@ -458,7 +458,7 @@ class WebManager(BaseModule):
 
         allow_loopback_without_key = os.getenv(
             'SMARTHOME_ALLOW_LOOPBACK_WITHOUT_KEY',
-            'true'
+            'false'
         ).strip().lower() in ('1', 'true', 'yes', 'on')
 
         if provided_key and hmac.compare_digest(provided_key, expected_key):

--- a/test_control_auth_security.py
+++ b/test_control_auth_security.py
@@ -1,0 +1,87 @@
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from modules.gateway.web_manager import WebManager
+
+
+class _DummyModuleManager:
+    def __init__(self, modules=None):
+        self._modules = modules or {}
+
+    def get_module(self, name):
+        return self._modules.get(name)
+
+
+class _DummyGateway:
+    def __init__(self):
+        self.writes = []
+
+    def write_variable(self, variable, value, plc_id):
+        self.writes.append((plc_id, variable, value))
+        return True
+
+    def set_correlation_id(self, correlation_id):
+        return None
+
+    def clear_correlation_id(self):
+        return None
+
+
+@pytest.fixture()
+def security_fixture(monkeypatch):
+    monkeypatch.setenv("SMARTHOME_ADMIN_API_KEY", "super-secret")
+    monkeypatch.setenv("SMARTHOME_ALLOW_LOOPBACK_WITHOUT_KEY", "false")
+    monkeypatch.setenv("SMARTHOME_CONTROL_RATE_LIMIT_MAX_REQUESTS", "500")
+
+    wm = WebManager()
+    wm.data_gateway = _DummyGateway()
+    wm.variable_manager = object()
+    wm.app_context = SimpleNamespace(module_manager=_DummyModuleManager({}))
+    wm._setup_flask()
+
+    return wm, wm.app.test_client()
+
+
+def test_control_api_rejects_non_loopback_without_api_key(security_fixture):
+    _, client = security_fixture
+    res = client.post(
+        "/api/variables/write",
+        json={"plc_id": "plc_001", "variable": "Light.Test.bOn", "value": True},
+        environ_overrides={"REMOTE_ADDR": "10.0.0.42"},
+    )
+    assert res.status_code == 401
+    payload = res.get_json()
+    assert payload["success"] is False
+    assert payload["error"] == "unauthorized"
+
+
+def test_control_api_rejects_loopback_without_api_key_when_disabled(security_fixture):
+    _, client = security_fixture
+    res = client.post(
+        "/api/admin/service/restart",
+        json={"delay": 2},
+        environ_overrides={"REMOTE_ADDR": "127.0.0.1"},
+    )
+    assert res.status_code == 401
+    payload = res.get_json()
+    assert payload["success"] is False
+    assert payload["error"] == "unauthorized"
+
+
+def test_control_api_accepts_valid_api_key(security_fixture):
+    wm, client = security_fixture
+    res = client.post(
+        "/api/variables/write",
+        json={"plc_id": "plc_001", "variable": "Light.Test.bOn", "value": True},
+        headers={"X-API-Key": "super-secret"},
+        environ_overrides={"REMOTE_ADDR": "10.0.0.42"},
+    )
+    assert res.status_code == 200
+    payload = res.get_json()
+    assert payload["status"] == "success"
+    assert wm.data_gateway.writes == [("plc_001", "Light.Test.bOn", True)]


### PR DESCRIPTION
## Summary
- make `SMARTHOME_ALLOW_LOOPBACK_WITHOUT_KEY` secure-by-default (`false`)
- update `.env.example` to reflect hardened default
- add regression tests for control-endpoint auth behavior
- run new security tests in CI smoke workflow

## Security impact
- critical control APIs no longer accept unauthenticated loopback requests by default when an admin API key is configured
- explicit opt-in remains possible for local fallback (`SMARTHOME_ALLOW_LOOPBACK_WITHOUT_KEY=true`)

## Validation
- `pytest -q test_control_auth_security.py`
- `pytest -q test_api_contracts.py test_integration_core_flows.py test_backup_manager.py`

Closes #2