### PR TITLE
[Follow-up] Copilot review fixes for restart semantics and daemon delay

### DIFF
--- a/docs/DOCKER_DEPLOYMENT.md
+++ b/docs/DOCKER_DEPLOYMENT.md
@@ -39,11 +39,12 @@ Damit bleiben Konfigurationen/State bei Container-Neustarts erhalten.
 ## Restart-Semantik in Docker
 
 - `POST /api/admin/service/restart`:
-  - Beendet den Hauptprozess kontrolliert.
+  - Triggert einen `SIGTERM` auf den laufenden Prozess (graceful shutdown-Pfad).
   - Docker `restart: unless-stopped` startet den Container neu.
 - `POST /api/admin/service/restart-daemon`:
   - Im Container bewusst deaktiviert.
   - API liefert klare Fehlermeldung (HTTP 400) und schreibt ein Audit-Event.
+  - Für Neustarts im Containerbetrieb sind Orchestrator-Mechanismen vorgesehen.
 
 ## Native Linux vs Docker
 

--- a/modules/core/service_manager.py
+++ b/modules/core/service_manager.py
@@ -16,6 +16,7 @@ import subprocess
 import platform
 import logging
 import time
+import signal
 from typing import Tuple
 
 
@@ -72,8 +73,9 @@ class ServiceManager:
             cwd = os.getcwd()
 
             if ServiceManager.is_container_runtime():
-                logger.warning("Container-Runtime erkannt: beende PID1 fuer orchestrator restart")
-                os._exit(0)
+                logger.warning("Container-Runtime erkannt: sende SIGTERM fuer orchestrator-konformen Neustart")
+                os.kill(os.getpid(), signal.SIGTERM)
+                return True
 
             # Robuster Restart über separaten Prozess:
             # vermeidet Socket-FD-Vererbung/Port-Konflikte bei execv.

--- a/modules/gateway/web_manager.py
+++ b/modules/gateway/web_manager.py
@@ -2026,6 +2026,7 @@ class WebManager(BaseModule):
                     delay = int(data.get('delay', 1))
                 except Exception:
                     delay = 1
+                delay = max(1, min(delay, 30))
                 project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
                 db_path = os.path.join(project_root, 'config', 'system_logs.db')
                 actor = request.headers.get('X-Admin-User') or request.remote_addr or 'unknown'

--- a/test_docker_runtime.py
+++ b/test_docker_runtime.py
@@ -1,3 +1,5 @@
+import signal
+
 from modules.core.service_manager import ServiceManager
 
 
@@ -13,3 +15,15 @@ def test_restart_info_exposes_container_flag(monkeypatch):
     info = ServiceManager.get_restart_info()
     assert "is_container_runtime" in info
     assert info["is_container_runtime"] is True
+
+
+def test_restart_service_uses_sigterm_in_container(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(ServiceManager, "is_container_runtime", staticmethod(lambda: True))
+    monkeypatch.setattr("os.kill", lambda pid, sig: calls.append((pid, sig)))
+
+    ok = ServiceManager.restart_service()
+    assert ok is True
+    assert len(calls) == 1
+    assert calls[0][1] == signal.SIGTERM


### PR DESCRIPTION
## Summary
Implements follow-up fixes from Copilot review after Docker readiness PR.

### Changes
1. `restart-daemon` delay clamping consistency
- `modules/gateway/web_manager.py`
- Clamp `delay` to `1..30` before scheduling/audit/response.
- Keeps audit and effective scheduling values consistent.

2. Graceful container restart semantics
- `modules/core/service_manager.py`
- In container runtime, `restart_service()` now sends `SIGTERM` to the current process instead of immediate `os._exit(0)`.
- Updated log message to avoid PID1-specific assumption.

3. Integration test aligned with real behavior
- `test_integration_core_flows.py`
- Rejection test now patches `ServiceManager.is_container_runtime()` and exercises real rejection path.
- Assertions updated to match clamped delay and real localized error text.

4. Docker restart documentation precision
- `docs/DOCKER_DEPLOYMENT.md`
- Documented SIGTERM-based graceful shutdown path and orchestrator restart expectation.

5. Additional runtime test
- `test_docker_runtime.py`
- Added test to ensure container restart path uses `SIGTERM`.

### Validation
- `.venv/bin/python -m py_compile modules/core/service_manager.py modules/gateway/web_manager.py`
- `.venv/bin/pytest -q test_integration_core_flows.py test_docker_runtime.py`

Closes #91
