### PR TITLE
[Admin] Restart-Logfilter: App/Dienst/Fehler

### DIFF
--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -960,7 +960,9 @@
                     <div class="flex items-center space-x-2">
                         <select id="logs-filter-select" class="px-2 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-900 text-gray-700 dark:text-gray-200">
                             <option value="all">Alle</option>
-                            <option value="restart">Restart</option>
+                            <option value="restart_app">Restart: App</option>
+                            <option value="restart_daemon">Restart: Dienst</option>
+                            <option value="restart_error">Restart: Fehler/abgelehnt</option>
                         </select>
                         <button id="refresh-logs-btn" class="px-3 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600">
                             <i data-lucide="refresh-cw" class="w-4 h-4 inline mr-1"></i> Aktualisieren


### PR DESCRIPTION
## Summary
Implements dedicated Admin log filters for restart troubleshooting.

### What changed
- Admin filter UI now offers:
  - `Alle`
  - `Restart: App`
  - `Restart: Dienst`
  - `Restart: Fehler/abgelehnt`
- `/api/admin/logs` filter logic extended:
  - `restart_app`
  - `restart_daemon`
  - `restart_error`
  - existing `restart` remains supported
- Filtering is robust for both:
  - structured audit entries (`action=...` in JSON payload)
  - warning/error text entries (`type=app|daemon`, `restart rejected`, etc.)
- Added integration test coverage for all new restart filter modes.

### Validation
- `.venv/bin/python -m py_compile modules/gateway/web_manager.py`
- `.venv/bin/pytest -q test_integration_core_flows.py`

Closes #1
