### PR TITLE
[Docs] Consolidate E2E docs + API drift check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,10 @@ jobs:
           python -m py_compile start_web_hmi.py module_manager.py import_tpy.py
           python -m compileall -q modules
 
+      - name: Verify API docs match code routes
+        run: |
+          python scripts/check_api_doc_drift.py
+
       - name: Run basic tests
         run: |
           python test_web_manager_fix.py

--- a/README.md
+++ b/README.md
@@ -24,8 +24,13 @@
 
 ## 📌 **Aktuelle Betriebsdoku (Web-HMI)**
 
-Für den aktuellen produktiven Ablauf (Web-Setup) bitte diese Anleitung verwenden:
+Für den aktuellen produktiven Ablauf sind diese Dokumente die verbindliche Quelle:
 
+- `docs/01_quickstart.md`
+- `docs/02_twincat_setup.md`
+- `docs/03_camera_setup.md`
+- `docs/04_gateway_integration.md`
+- `docs/05_api_reference.md`
 - `docs/WEB_SETUP_ROUTING_ADS_GUIDE.md`
 - `docs/STAGING_GATE.md` (Release-Gates, Canary, Go/No-Go)
 - `docs/SECURITY_INCIDENT_SENTRY_DSN.md` (Incident-Runbook & Secret-Policy)
@@ -37,6 +42,7 @@ Inhalt:
 - Routing-Regeln über Setup-UI bearbeiten (`config/routing.json`)
 - Docker-Hardening/Least-Privilege: `docs/DOCKER_LEAST_PRIVILEGE.md`
 - Release-Verifikation (Checksums + Attestation): `docs/RELEASE_VERIFICATION.md`
+- Dokumentations-Index + Historisch-Markierung: `docs/README.md`
 
 ---
 

--- a/docs/01_quickstart.md
+++ b/docs/01_quickstart.md
@@ -1,0 +1,40 @@
+# 01 Quickstart (Web-HMI)
+
+Dies ist der verbindliche Startpfad fuer neue Installationen.
+
+## Voraussetzungen
+- Linux Host oder Docker Runtime
+- Python 3.11+
+- Node.js/npm (nur fuer Ring-Bridge Runtime)
+- ffmpeg (Kamera-Streams)
+
+## Installation (native Linux)
+```bash
+cd /opt/Smarthome-Web
+python3 -m venv .venv
+. .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+npm ci --omit=dev --ignore-scripts
+cp .env.example .env
+```
+
+## Start
+```bash
+. .venv/bin/activate
+python start_web_hmi.py --host 0.0.0.0 --port 5000
+```
+
+## Healthcheck
+```bash
+curl -fsS http://127.0.0.1:5000/api/system/status
+```
+
+## Docker-Alternative
+Siehe `docs/DOCKER_DEPLOYMENT.md`.
+
+## Nächster Schritt
+1. TwinCAT einrichten: `docs/02_twincat_setup.md`
+2. Kameras einbinden: `docs/03_camera_setup.md`
+3. Gateway-Integration: `docs/04_gateway_integration.md`
+4. API-Referenz: `docs/05_api_reference.md`

--- a/docs/02_twincat_setup.md
+++ b/docs/02_twincat_setup.md
@@ -1,0 +1,40 @@
+# 02 TwinCAT Setup
+
+Verbindlicher Ablauf fuer ADS/TwinCAT (TC2/TC3).
+
+## Setup in der Web-UI
+Pfad: `Setup -> PLC-Konfiguration`
+
+- Runtime waehlen:
+  - `TC2` -> Standard-Port `801`
+  - `TC3` -> Standard-Port `851`
+- `AMS Net ID` und optional `IP-Adresse` setzen
+- `Verbinden`
+
+## ADS-Routen
+Pfad: `Setup -> ADS TwinCAT Routen`
+
+- `Status` pruefen
+- Route anlegen (`/api/plc/ads/route/add`)
+- Route testen (`/api/plc/ads/route/test`)
+
+## Minimale API-Flows
+### Verbindung
+`POST /api/plc/connect`
+```json
+{
+  "ams_id": "192.168.2.162.1.1",
+  "runtime_type": "TC3"
+}
+```
+
+### Trennen
+`POST /api/plc/disconnect`
+
+### Symbol-Livewerte
+`POST /api/plc/symbols/live`
+
+## Troubleshooting
+- Route nicht erreichbar: `GET /api/plc/ads/route/status`
+- Runtime falsch: Port gegen TC2/TC3 abgleichen
+- PLC-Schreibtest: `POST /api/variables/write`

--- a/docs/03_camera_setup.md
+++ b/docs/03_camera_setup.md
@@ -1,0 +1,39 @@
+# 03 Camera Setup (RTSP + Ring)
+
+Kamera-Streams sind ein First-Class-Use-Case des Gateways.
+
+## RTSP Kamera
+### UI
+Pfad: `Setup -> Kameras`
+
+- Kamera anlegen (ID + URL)
+- Testen via Diagnose
+- Stream starten
+
+### API
+- Kamera speichern: `POST /api/cameras`
+- Liste: `GET /api/cameras`
+- Diagnose: `POST /api/cameras/diagnose`
+- Auto-Scan: `POST /api/cameras/scan`
+- Stream starten: `POST /api/cameras/<cam_id>/start`
+- Stream stoppen: `POST /api/cameras/<cam_id>/stop`
+
+## Ring Kamera
+### Voraussetzungen
+- `ring-client-api` via npm
+- `RING_REFRESH_TOKEN` gesetzt
+
+### API
+- Auth setzen: `POST /api/ring/auth`
+- Ring-Kameras abrufen: `GET /api/ring/cameras`
+- Ring-Kameras importieren: `POST /api/ring/cameras/import`
+
+## PTZ (ONVIF)
+- Status: `GET /api/cameras/<cam_id>/ptz/status`
+- Move: `POST /api/cameras/<cam_id>/ptz/move`
+- Stop: `POST /api/cameras/<cam_id>/ptz/stop`
+
+## Troubleshooting
+- Leere HLS-Ausgabe: ffmpeg vorhanden?
+- Ring stockt: Node/Ring-Abhaengigkeiten und Token pruefen
+- Stream instabil: `GET /api/monitor/streams` und `/api/monitor/slo`

--- a/docs/04_gateway_integration.md
+++ b/docs/04_gateway_integration.md
@@ -1,0 +1,42 @@
+# 04 Gateway Integration
+
+Dieser Vertrag beschreibt, wie externe Systeme ans interne Gateway andocken.
+
+## DataGateway Kernidee
+`route_data(source, tag, value, metadata)` normalisiert Daten und verteilt sie an Ziele (z. B. UI, MQTT, PLC).
+
+## Routing-Konfiguration
+Datei: `config/routing.json`
+
+Beispiel:
+```json
+{
+  "version": "1.0",
+  "routes": [
+    {
+      "id": "camera_alert_to_mqtt",
+      "from": "Alarm.Camera.*",
+      "to": ["websocket", "mqtt"],
+      "enabled": true
+    }
+  ]
+}
+```
+
+## Relevante API-Endpunkte
+- Routing lesen/schreiben: `GET|POST /api/routing/config`
+- Variablen schreiben: `POST /api/variables/write`
+- Variablen lesen: `POST /api/variables/read`
+- Telemetrie: `GET /api/telemetry`
+- Datenfluss/Monitoring: `GET /api/monitor/dataflow`, `GET /api/monitor/latency`
+
+## Kamera-Gateway-Use-Case
+Kameraevents und Stream-Status koennen wie andere Signale geroutet werden.
+Damit ist "Gateway managt auch Kamera-Streams" technisch und dokumentarisch offizieller Bestandteil.
+
+## Fehlerverhalten
+- Rate-Limits und Auth gelten fuer Control-Endpunkte
+- DLQ-Funktionen fuer Reprocess/Clear:
+  - `GET /api/monitor/dlq`
+  - `POST /api/monitor/dlq/reprocess`
+  - `POST /api/monitor/dlq/clear`

--- a/docs/05_api_reference.md
+++ b/docs/05_api_reference.md
@@ -1,0 +1,70 @@
+# 05 API Reference (verbindlich)
+
+Nur hier gelistete Endpunkte gelten als dokumentierter API-Stand.
+
+## System
+- `GET /api/system/status`
+- `GET /api/system/dependencies`
+- `GET /api/telemetry`
+
+## PLC / TwinCAT
+- `GET /api/plc/config`
+- `POST /api/plc/config`
+- `POST /api/plc/connect`
+- `POST /api/plc/disconnect`
+- `GET /api/plc/ads/route/status`
+- `POST /api/plc/ads/route/add`
+- `POST /api/plc/ads/route/test`
+- `GET /api/plc/symbols`
+- `POST /api/plc/symbols/upload`
+- `POST /api/plc/symbols/live`
+
+## Variablen
+- `GET /api/variables/search`
+- `POST /api/variables/write`
+- `POST /api/variables/read`
+- `GET /api/variables/statistics`
+
+## Kamera / Ring
+- `GET /api/cameras`
+- `POST /api/cameras`
+- `PUT /api/cameras/<cam_id>`
+- `DELETE /api/cameras/<cam_id>`
+- `POST /api/cameras/scan`
+- `POST /api/cameras/diagnose`
+- `POST /api/cameras/alert`
+- `GET /api/cameras/<cam_id>/snapshot`
+- `POST /api/cameras/<cam_id>/start`
+- `POST /api/cameras/<cam_id>/stop`
+- `GET /api/ring/status`
+- `POST /api/ring/auth`
+- `GET /api/ring/cameras`
+- `POST /api/ring/cameras/import`
+
+## Routing / Trigger
+- `GET /api/routing/config`
+- `POST /api/routing/config`
+- `GET /api/camera-triggers`
+- `POST /api/camera-triggers`
+- `GET /api/camera-triggers/export`
+- `POST /api/camera-triggers/import`
+
+## Admin
+- `GET /api/admin/plcs`
+- `POST /api/admin/plcs`
+- `GET /api/admin/logs`
+- `GET /api/admin/logs/verify`
+- `GET /api/admin/logs/export`
+- `POST /api/admin/logs/clear`
+- `GET /api/admin/service/info`
+- `POST /api/admin/service/restart`
+- `POST /api/admin/service/restart-daemon`
+
+## Monitoring
+- `GET /api/monitor/dataflow`
+- `GET /api/monitor/latency`
+- `GET /api/monitor/slo`
+- `GET /api/monitor/streams`
+- `GET /api/monitor/dlq`
+- `POST /api/monitor/dlq/reprocess`
+- `POST /api/monitor/dlq/clear`

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,68 +1,16 @@
-# README
+# Dokumentations-Index
 
-## Projektübersicht
-Dieses Projekt ist eine modulare, hochgradig erweiterbare Middleware‑Plattform zur Verarbeitung, Verteilung und Visualisierung technischer Daten aus unterschiedlichsten Quellen wie SPS/PLC‑Systemen, Bluetooth‑Geräten, MQTT‑Brokern, RS485‑Modulen oder weiteren Sensor‑ und Kommunikationssystemen.
+## Kanonische Betriebsdoku (normativ)
+Diese Dateien sind der verbindliche Stand fuer Betrieb, Integration und API:
 
-Mit Version **v5.1.0** entwickelt sich das System von einer klassischen HMI‑Visualisierung zu einem **Universal Data Hub**, in dem sämtliche Datenpunkte zentral erfasst, normalisiert, verarbeitet und über deklarative Regeln weitergeleitet werden.
+- `docs/01_quickstart.md`
+- `docs/02_twincat_setup.md`
+- `docs/03_camera_setup.md`
+- `docs/04_gateway_integration.md`
+- `docs/05_api_reference.md`
+- `docs/DOCKER_DEPLOYMENT.md`
+- `docs/STAGING_GATE.md`
+- `docs/SECURITY_INCIDENT_SENTRY_DSN.md`
 
-Der Benutzer kann **jeden gerouteten Datenpunkt** – unabhängig von dessen Ursprung – **ohne Programmierung direkt im Dashboard visualisieren**, binden oder automatisieren.
-
----
-
-## Hauptfunktionen
-- Verwaltung beliebig vieler paralleler Verbindungen (PLC, MQTT, Bluetooth, RS485, CAN, TCP/UDP)
-- Router für deklarative Datenwege (z. B. Bluetooth‑Sensor → PLC‑Variable → MQTT‑Alarm → UI‑Widget)
-- Plugin‑System für zusätzliche Protokolle, Analysemodule oder Automationslogiken
-- UI‑Widget‑Editor (Drag & Drop) zur schnellen Erstellung individueller Dashboards
-- Einheitlicher Datenraum (Unified Data Space) für alle eingehenden Werte
-- Vollständige Entkopplung von Hardware, Routing‑Logik und UI
-
----
-
-## Architektur
-### DataGateway
-Das zentrale Element der Plattform. Es verarbeitet sämtliche Datenpakete nach folgendem Fluss:
-```
-Quelle → Normalisierung → Routing → Ziel(e) → Visualisierung/Automatisierung
-```
-
-### Connection Manager
-Verwaltet parallele Datenquellen, führt Health‑Checks durch, übernimmt Reconnect‑Strategien und abstrahiert die jeweiligen Protokolle.
-
-### routing.json
-Deklaratives Regelwerk, das festlegt:
-- welche Datenpunkte weitergeleitet werden
-- wohin sie gesendet werden
-- ob sie transformiert, gefiltert oder aggregiert werden
-
-### Plugin‑Interface
-Ermöglicht die Integration zusätzlicher Hardware‑Module, Datenquellen oder Analysekomponenten.
-
----
-
-## Installation
-1. Repository klonen
-2. Abhängigkeiten installieren
-3. Gateway starten
-4. Verbindungen im Connection Manager konfigurieren
-5. Routen in `routing.json` definieren
-6. Dashboard mit Widgets bestücken
-
----
-
-## Nutzung
-- Verbindungen einrichten (Bluetooth, PLC, MQTT etc.)
-- Routing‑Regeln anlegen
-- Widgets im Editor platzieren und miteinander verknüpfen
-- Datenpunkte in Echtzeit visualisieren
-- Optional: Automationen über Plugins oder Routing‑Transformen
-
----
-
-## Lizenz
-Siehe LICENSE Datei im Repository.
-
----
-
-## Version
-v5.1.0
+## Historische Dokumente
+Alle anderen Dateien unter `docs/`, die nicht oben genannt sind, gelten als **historisch/nicht normativ** (Release-Notizen, alte Roadmaps, Hotfix-Protokolle).

--- a/scripts/check_api_doc_drift.py
+++ b/scripts/check_api_doc_drift.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Validate that documented API endpoints exist in web_manager routes."""
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "docs" / "05_api_reference.md"
+SRC = ROOT / "modules" / "gateway" / "web_manager.py"
+
+DOC_PATTERN = re.compile(r"^\s*-\s*`(GET|POST|PUT|DELETE|PATCH)\s+(/api/[^`]+)`\s*$")
+ROUTE_PATTERN = re.compile(
+    r"@self\.app\.route\('\s*(/api[^']*)\s*'(?:,\s*methods=\[(.*?)\])?"
+)
+METHOD_PATTERN = re.compile(r"'([A-Z]+)'")
+
+
+def load_documented() -> set[tuple[str, str]]:
+    documented: set[tuple[str, str]] = set()
+    for line in DOC.read_text(encoding="utf-8").splitlines():
+        m = DOC_PATTERN.match(line)
+        if m:
+            documented.add((m.group(1), m.group(2)))
+    return documented
+
+
+def load_routes() -> set[tuple[str, str]]:
+    routes: set[tuple[str, str]] = set()
+    content = SRC.read_text(encoding="utf-8")
+    for m in ROUTE_PATTERN.finditer(content):
+        path = m.group(1).strip()
+        methods_group = m.group(2)
+        methods = ["GET"]
+        if methods_group:
+            methods = METHOD_PATTERN.findall(methods_group) or ["GET"]
+        for method in methods:
+            routes.add((method, path))
+    return routes
+
+
+def main() -> int:
+    documented = load_documented()
+    routes = load_routes()
+    missing = sorted(documented - routes)
+
+    if missing:
+        print("API doc drift detected. Missing in code:")
+        for method, path in missing:
+            print(f"- {method} {path}")
+        return 1
+
+    print(f"API doc check passed ({len(documented)} documented endpoints found in code).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Consolidates project documentation into canonical end-to-end operations guides and adds CI validation to prevent API doc drift.

### What changed
- Added canonical docs (single source of truth):
  - `docs/01_quickstart.md`
  - `docs/02_twincat_setup.md`
  - `docs/03_camera_setup.md`
  - `docs/04_gateway_integration.md`
  - `docs/05_api_reference.md`
- Reworked `docs/README.md`:
  - explicit normative doc set
  - explicit historical/non-normative classification for other docs
- Updated root `README.md` links to canonical docs.
- Added API doc drift check script:
  - `scripts/check_api_doc_drift.py`
  - validates documented endpoints from `docs/05_api_reference.md` against real `@route` declarations in `modules/gateway/web_manager.py`
- Added CI step in `.github/workflows/ci.yml`:
  - `python scripts/check_api_doc_drift.py`

### Validation
- `.venv/bin/python scripts/check_api_doc_drift.py`
- `.venv/bin/pytest -q test_api_contracts.py`

Closes #5
