### PR TITLE
[DevEx] Add Makefile for standard workflows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,9 +14,13 @@
 Run before opening a PR:
 
 ```bash
-python3 -m py_compile start_web_hmi.py module_manager.py import_tpy.py
-python3 -m compileall -q modules
-venv/bin/python -m pytest -q test_web_manager_fix.py test_logging_system.py
+make smoke
+```
+
+For a full local CI-equivalent run:
+
+```bash
+make test
 ```
 
 ## PR Checklist

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,52 @@
+SHELL := /bin/bash
+
+PYTHON := $(shell if [ -x .venv/bin/python ]; then echo .venv/bin/python; else echo python3; fi)
+PIP := $(shell if [ -x .venv/bin/pip ]; then echo .venv/bin/pip; else echo pip3; fi)
+
+.PHONY: help install lint check-api-docs test smoke run docker-up docker-down
+
+help:
+	@echo "Targets:"
+	@echo "  install         Install Python/Node dependencies"
+	@echo "  lint            Syntax and static compile checks"
+	@echo "  check-api-docs  Validate docs/05_api_reference.md against code routes"
+	@echo "  test            Full local test suite used in CI smoke job"
+	@echo "  smoke           Fast local smoke checks"
+	@echo "  run             Start Web-HMI"
+	@echo "  docker-up       Build and start docker compose stack"
+	@echo "  docker-down     Stop docker compose stack"
+
+install:
+	$(PIP) install --upgrade pip
+	$(PIP) install -r requirements.txt
+	npm ci --omit=dev --ignore-scripts
+
+lint:
+	$(PYTHON) -m py_compile start_web_hmi.py module_manager.py import_tpy.py
+	$(PYTHON) -m compileall -q modules
+
+check-api-docs:
+	$(PYTHON) scripts/check_api_doc_drift.py
+
+test: lint check-api-docs
+	$(PYTHON) test_web_manager_fix.py
+	$(PYTHON) test_logging_system.py
+	$(PYTHON) -m pytest -q test_api_contracts.py
+	$(PYTHON) -m pytest -q test_backup_manager.py
+	$(PYTHON) -m pytest -q test_integration_core_flows.py
+	$(PYTHON) -m pytest -q test_control_auth_security.py
+	$(PYTHON) -m pytest -q test_circuit_breakers.py
+	$(PYTHON) -m pytest -q test_docker_runtime.py
+	$(PYTHON) -m pytest -q test_secret_hygiene.py
+
+smoke: lint check-api-docs
+	$(PYTHON) -m pytest -q test_api_contracts.py test_integration_core_flows.py
+
+run:
+	$(PYTHON) start_web_hmi.py
+
+docker-up:
+	docker compose up -d --build
+
+docker-down:
+	docker compose down -v


### PR DESCRIPTION
## Summary
Adds a standard `Makefile` for reproducible local developer workflows and updates contributing validation commands.

### Included targets
- `test`
- `smoke`
- `lint`
- `run`
- `docker-up`
- `docker-down`
- plus `install` and `check-api-docs`

### Details
- `Makefile` automatically prefers `.venv/bin/python` if available, otherwise `python3`.
- `make smoke` provides a fast pre-PR check.
- `make test` mirrors core local CI/smoke checks.
- `CONTRIBUTING.md` now recommends `make smoke` and `make test`.

### Validation
- `make smoke`

Closes #15
