### PR TITLE
feat(api): deprecation policy + versioning strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Für den aktuellen produktiven Ablauf sind diese Dokumente die verbindliche Quel
 - `docs/03_camera_setup.md`
 - `docs/04_gateway_integration.md`
 - `docs/05_api_reference.md`
+- `docs/06_api_lifecycle_policy.md`
 - `docs/WEB_SETUP_ROUTING_ADS_GUIDE.md`
 - `docs/STAGING_GATE.md` (Release-Gates, Canary, Go/No-Go)
 - `docs/SECURITY_INCIDENT_SENTRY_DSN.md` (Incident-Runbook & Secret-Policy)

--- a/docs/05_api_reference.md
+++ b/docs/05_api_reference.md
@@ -2,9 +2,20 @@
 
 Nur hier gelistete Endpunkte gelten als dokumentierter API-Stand.
 
+## Versionierung und Deprecation
+- Aktueller stabiler API-Major: `v1`
+- Aktueller Namespace: `/api/*` (entspricht `v1`)
+- Breaking Changes nur über neuen Major-Namespace (z. B. `/api/v2/*`)
+- Deprecation-Fenster vor Entfernen: mindestens `90` Tage
+- Laufende Policy und Sunset-Regeln: `docs/06_api_lifecycle_policy.md`
+- Runtime-Signale:
+- `X-API-Version`, `X-API-Major-Version`, `X-API-Compatibility-Model` auf allen `/api/*`-Responses
+- Für deprecated Endpunkte zusätzlich: `Deprecation`, `Sunset`, optional `X-API-Replacement`
+
 ## System
 - `GET /api/system/status`
 - `GET /api/system/dependencies`
+- `GET /api/system/versioning`
 - `GET /api/telemetry`
 
 ## PLC / TwinCAT

--- a/docs/06_api_lifecycle_policy.md
+++ b/docs/06_api_lifecycle_policy.md
@@ -1,0 +1,57 @@
+# 06 API Lifecycle Policy (verbindlich)
+
+Dieses Dokument definiert das verbindliche Kompatibilitätsmodell für öffentliche Gateway-APIs.
+
+## Ziele
+- Integrationen bleiben über Minor/Patch-Releases stabil.
+- Breaking Changes sind planbar und haben klare Migrationspfade.
+- Deprecated Endpunkte sind zur Laufzeit und in der Doku eindeutig markiert.
+
+## Versionsstrategie
+- Aktueller API-Major: `v1`
+- Aktueller stabiler Namespace: `/api/*` (semantisch `v1`)
+- Neue Breaking Changes werden nur als neuer Major eingeführt:
+- Beispiel: `/api/v2/*`
+- `v1` bleibt während der Übergangsphase weiterhin verfügbar.
+
+## Deprecation-Policy
+- Mindestlaufzeit zwischen Deprecation und Removal: `90` Tage
+- Jeder deprecated Endpunkt braucht:
+- Sunset-Datum (UTC, ISO 8601)
+- dokumentierten Replacement-Pfad (wenn verfügbar)
+- Begründung/Migrationshinweis
+- Runtime-Signal für deprecated Endpunkte:
+- `Deprecation: true`
+- `Sunset: <RFC1123-Datum>`
+- optional `X-API-Replacement`, `X-API-Deprecation-Reason`
+
+## Breaking-Change-Prozess
+1. Änderung als Issue + ADR dokumentieren (Scope, Risiko, Migration).
+2. Neue Major-Route bereitstellen (`/api/vN/...`) und Contract-Tests ergänzen.
+3. Alte Route als deprecated markieren (Header + Doku + Changelog).
+4. Nach Ablauf des Sunset-Fensters alte Route entfernen.
+5. Entfernen als Breaking Change im Release klar kennzeichnen.
+
+## Runtime-Verträge
+- Alle `/api/*`-Responses liefern:
+- `X-API-Version`
+- `X-API-Major-Version`
+- `X-API-Compatibility-Model`
+- `X-API-Lifecycle-Policy`
+- Policy-Discovery-Endpunkt:
+- `GET /api/system/versioning`
+
+## Konfiguration
+- Deprecated Endpunkte können über Umgebungsvariable gesetzt werden:
+- `SMARTHOME_API_DEPRECATED_ENDPOINTS`
+- Format:
+
+```json
+{
+  "/api/example/legacy": {
+    "sunset": "2026-12-31T00:00:00Z",
+    "replacement": "/api/v2/example",
+    "reason": "v2 uses normalized payload schema"
+  }
+}
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ Diese Dateien sind der verbindliche Stand fuer Betrieb, Integration und API:
 - `docs/03_camera_setup.md`
 - `docs/04_gateway_integration.md`
 - `docs/05_api_reference.md`
+- `docs/06_api_lifecycle_policy.md`
 - `docs/DOCKER_DEPLOYMENT.md`
 - `docs/STAGING_GATE.md`
 - `docs/SECURITY_INCIDENT_SENTRY_DSN.md`

--- a/test_api_contracts.py
+++ b/test_api_contracts.py
@@ -106,6 +106,9 @@ def test_contract_system_status_schema(web_fixture):
     _, client = web_fixture
     res = client.get("/api/system/status")
     assert res.status_code == 200
+    assert res.headers.get("X-API-Version") == "v1"
+    assert res.headers.get("X-API-Major-Version") == "1"
+    assert res.headers.get("X-API-Compatibility-Model") == "major-path"
     payload = res.get_json()
     assert isinstance(payload, dict)
     for key in ("status", "plc", "capabilities", "blob_stats", "telemetry_count", "uptime"):
@@ -127,6 +130,19 @@ def test_contract_monitor_slo_schema(web_fixture):
     assert isinstance(payload["sli"], dict)
     assert "api" in payload["sli"]
     assert "streams" in payload["sli"]
+
+
+def test_contract_api_versioning_policy_endpoint(web_fixture):
+    _, client = web_fixture
+    res = client.get("/api/system/versioning")
+    assert res.status_code == 200
+    payload = res.get_json()
+    assert payload["current_major"] == 1
+    assert payload["current_namespace"] == "/api"
+    assert payload["compatibility_model"] == "major-path"
+    assert payload["deprecation_min_days"] == 90
+    assert payload["policy_document"] == "docs/06_api_lifecycle_policy.md"
+    assert isinstance(payload["deprecated_endpoints"], list)
 
 
 def test_contract_error_code_for_missing_variable(web_fixture):


### PR DESCRIPTION
## Summary
- add enforceable API lifecycle headers for all `/api/*` responses
- add `/api/system/versioning` policy discovery endpoint
- document canonical deprecation/versioning policy in docs
- extend API contract tests for lifecycle headers and policy endpoint

## Validation
- `.venv/bin/python -m py_compile modules/gateway/web_manager.py`
- `.venv/bin/python scripts/check_api_doc_drift.py`
- `.venv/bin/pytest -q test_api_contracts.py`

Closes #24