### PR TITLE
docs(architecture): establish ADR process

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Für den aktuellen produktiven Ablauf sind diese Dokumente die verbindliche Quel
 - `docs/07_operations_playbook.md`
 - `docs/openapi.json`
 - `docs/08_socket_events.md`
+- `docs/ADR/README.md`
 - `docs/WEB_SETUP_ROUTING_ADS_GUIDE.md`
 - `docs/STAGING_GATE.md` (Release-Gates, Canary, Go/No-Go)
 - `docs/SECURITY_INCIDENT_SENTRY_DSN.md` (Incident-Runbook & Secret-Policy)

--- a/docs/ADR/0000-template.md
+++ b/docs/ADR/0000-template.md
@@ -1,0 +1,34 @@
+# ADR NNNN: <Titel>
+
+- Status: proposed
+- Date: YYYY-MM-DD
+- Deciders: <Rolle/Name>
+- Technical Story: <Issue/PR/Incident>
+
+## Context
+
+<Problem, Constraints, betroffene Systeme>
+
+## Decision Drivers
+
+- <Treiber 1>
+- <Treiber 2>
+
+## Considered Options
+
+- Option A
+- Option B
+
+## Decision
+
+<gewählte Option + Begründung>
+
+## Consequences
+
+- Positiv: <...>
+- Negativ: <...>
+- Risiko/Mitigation: <...>
+
+## References
+
+- <Links auf Issues/PRs/Docs>

--- a/docs/ADR/0001-api-lifecycle-policy.md
+++ b/docs/ADR/0001-api-lifecycle-policy.md
@@ -1,0 +1,44 @@
+# ADR 0001: API Lifecycle Policy und Contract-First Dokumentation
+
+- Status: accepted
+- Date: 2026-02-21
+- Deciders: Maintainer Team
+- Technical Story: #24, #14
+
+## Context
+
+Externe Integratoren brauchen stabile HTTP- und Socket-Verträge. Bisher waren Endpunkte dokumentiert, aber ohne maschinenlesbare OpenAPI-Spezifikation und ohne standardisierte Lifecycle-Regeln.
+
+## Decision Drivers
+
+- Integrationssicherheit für Drittclients
+- Nachvollziehbarer Deprecation-/Breaking-Change-Prozess
+- CI-gesicherte Drift-Erkennung zwischen Doku und Umsetzung
+
+## Considered Options
+
+- Option A: Nur prose-Dokumentation
+- Option B: Contract-first mit OpenAPI + Socket-Event-Schema + Drift-Checks
+
+## Decision
+
+Wir verwenden Option B.
+
+Konkrete Artefakte:
+- `docs/openapi.json`
+- `docs/08_socket_events.md`
+- `docs/06_api_lifecycle_policy.md`
+- CI-Checks: `scripts/check_api_doc_drift.py`, `scripts/check_openapi_contract_drift.py`
+
+## Consequences
+
+- Positiv: Integrationsverträge sind maschinenlesbar und CI-validiert.
+- Negativ: Zusätzlicher Pflegeaufwand bei API-Änderungen.
+- Risiko/Mitigation: Vertragsdrift wird über CI-Checks früh erkannt.
+
+## References
+
+- `docs/05_api_reference.md`
+- `docs/06_api_lifecycle_policy.md`
+- `docs/08_socket_events.md`
+- `docs/openapi.json`

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -1,0 +1,31 @@
+# ADR Process (verbindlich)
+
+ADR = Architecture Decision Record.
+
+## Zweck
+- Technische Entscheidungen nachvollziehbar und auditierbar dokumentieren.
+- Kontext, Alternativen und Konsequenzen langfristig auffindbar halten.
+
+## Ablage und Nummerierung
+- Ablageort: `docs/ADR/`
+- Dateiformat: `NNNN-kurzer-titel.md`
+- Nummern sind fortlaufend und werden nicht wiederverwendet.
+
+## Statuswerte
+- `proposed`: in Diskussion
+- `accepted`: beschlossen
+- `superseded`: durch neue ADR ersetzt
+- `deprecated`: nicht mehr gültig
+
+## Workflow
+1. ADR-Entwurf aus `docs/ADR/0000-template.md` erstellen.
+2. Kontext, Optionen und Trade-offs nachvollziehbar ausfüllen.
+3. Review im PR einholen (Architektur/Owner + betroffene Module).
+4. Bei Merge Status auf `accepted` setzen.
+5. Bei Folgeentscheidungen neue ADR erstellen und alte per `Superseded by` verlinken.
+
+## Mindestkriterien
+- Problem klar beschrieben
+- mindestens zwei Optionen mit Vor-/Nachteilen
+- Entscheidung und Konsequenzen explizit
+- Migrations-/Betriebsfolgen genannt

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Diese Dateien sind der verbindliche Stand fuer Betrieb, Integration und API:
 - `docs/07_operations_playbook.md`
 - `docs/openapi.json`
 - `docs/08_socket_events.md`
+- `docs/ADR/README.md`
 - `docs/DOCKER_DEPLOYMENT.md`
 - `docs/STAGING_GATE.md`
 - `docs/SECURITY_INCIDENT_SENTRY_DSN.md`


### PR DESCRIPTION
## Summary
- establish canonical ADR workflow in `docs/ADR/README.md`
- add reusable ADR template `docs/ADR/0000-template.md`
- add initial accepted ADR `docs/ADR/0001-api-lifecycle-policy.md`
- link ADR process in canonical docs index and root README

## Validation
- `.venv/bin/python scripts/check_api_doc_drift.py`
- `.venv/bin/python scripts/check_openapi_contract_drift.py`

Closes #46
