### PR TITLE
docs(architecture): module boundaries and ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Für den aktuellen produktiven Ablauf sind diese Dokumente die verbindliche Quel
 - `docs/openapi.json`
 - `docs/08_socket_events.md`
 - `docs/ADR/README.md`
+- `docs/09_module_boundaries_ownership.md`
 - `docs/WEB_SETUP_ROUTING_ADS_GUIDE.md`
 - `docs/STAGING_GATE.md` (Release-Gates, Canary, Go/No-Go)
 - `docs/SECURITY_INCIDENT_SENTRY_DSN.md` (Incident-Runbook & Secret-Policy)

--- a/docs/09_module_boundaries_ownership.md
+++ b/docs/09_module_boundaries_ownership.md
@@ -1,0 +1,46 @@
+# 09 Module Boundaries and Ownership (verbindlich)
+
+Dieses Dokument definiert technische Schnittgrenzen und Verantwortlichkeiten pro Modulbereich.
+
+## Architekturgrenzen
+- `modules/core`: plattformnahe Kernlogik (Config, Backup, Service, Security, Logging)
+- `modules/gateway`: externe Schnittstellen (HTTP API, Socket, Gateway-Orchestrierung)
+- `modules/plc`: TwinCAT/ADS Integration, Symbol-/Variablenzugriff
+- `modules/integrations`: externe Systeme (z. B. Kamera/Ring)
+- `modules/bluetooth`: BMS/Bluetooth-Parser und Protokolladapter
+- `modules/ui`: UI-Backend-Logik (nicht Web-Frontend)
+- `modules/plugins`: erweiterbare Funktionsmodule
+
+## Ownership-Matrix
+| Bereich | Primär-Owner | Sekundär-Owner | Review-Pflicht bei Änderungen |
+|---|---|---|---|
+| `modules/core` | Platform/Core Team | Security Owner | ja |
+| `modules/gateway` | API/Gateway Team | Platform/Core Team | ja |
+| `modules/plc` | PLC Integration Team | API/Gateway Team | ja |
+| `modules/integrations` | Integrations Team | API/Gateway Team | ja |
+| `modules/bluetooth` | Integrations Team | Platform/Core Team | ja |
+| `modules/ui` | UI Team | API/Gateway Team | ja |
+| `modules/plugins` | Feature Team | API/Gateway Team | bei API-Auswirkung |
+| `docs/*` | Maintainer Team | jeweiliger Fach-Owner | ja |
+
+## Schnittstellenregeln
+- `core` kennt keine Frontend-spezifischen Details.
+- `gateway` ist einzige öffentliche API-/Socket-Kante nach außen.
+- `plc` wird nicht direkt vom Frontend konsumiert; Zugriff immer über `gateway`.
+- `integrations` publizieren Ereignisse/Telemetrie über `gateway` statt eigener Outbound-APIs.
+- Contract-Änderungen benötigen Doku-Update (`docs/05`, `docs/openapi.json`, `docs/08`).
+
+## Change-Impact-Regeln
+1. API/Socket-Vertragsänderung:
+- Pflicht: `docs/05_api_reference.md`, `docs/openapi.json`, `docs/08_socket_events.md`, Contract-Tests.
+2. Security-/Auth-Änderung:
+- Pflicht: Security-Review + Regressionstests für Control-Endpunkte.
+3. PLC-Routing/Config-Schema-Änderung:
+- Pflicht: Migrationspfad + Backward-Compatibility-Check.
+4. Stream-/Kamera-Pipeline-Änderung:
+- Pflicht: Soak/Restart-Test und Incident-Playbook-Abgleich (`docs/07`).
+
+## Review-Gates
+- Jeder PR muss betroffene Module benennen (`Scope: core/gateway/plc/...`).
+- Bei Cross-Module-PRs ist mindestens ein zusätzlicher Owner-Review aus betroffenem Bereich nötig.
+- Architekturentscheidungen über Modulgrenzen werden als ADR festgehalten (`docs/ADR/README.md`).

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Diese Dateien sind der verbindliche Stand fuer Betrieb, Integration und API:
 - `docs/openapi.json`
 - `docs/08_socket_events.md`
 - `docs/ADR/README.md`
+- `docs/09_module_boundaries_ownership.md`
 - `docs/DOCKER_DEPLOYMENT.md`
 - `docs/STAGING_GATE.md`
 - `docs/SECURITY_INCIDENT_SENTRY_DSN.md`


### PR DESCRIPTION
## Summary
- add canonical module boundary and ownership document `docs/09_module_boundaries_ownership.md`
- define module responsibilities, interface rules and change-impact rules
- define review gates for cross-module changes and ADR escalation
- link document in canonical docs index and root README

## Validation
- `.venv/bin/python scripts/check_api_doc_drift.py`
- `.venv/bin/python scripts/check_openapi_contract_drift.py`

Closes #36
