### PR TITLE
docs(devops): blue-green and atomic deployment strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Für den aktuellen produktiven Ablauf sind diese Dokumente die verbindliche Quel
 - `docs/08_socket_events.md`
 - `docs/ADR/README.md`
 - `docs/09_module_boundaries_ownership.md`
+- `docs/10_blue_green_atomic_deployment.md`
 - `docs/WEB_SETUP_ROUTING_ADS_GUIDE.md`
 - `docs/STAGING_GATE.md` (Release-Gates, Canary, Go/No-Go)
 - `docs/SECURITY_INCIDENT_SENTRY_DSN.md` (Incident-Runbook & Secret-Policy)

--- a/docs/10_blue_green_atomic_deployment.md
+++ b/docs/10_blue_green_atomic_deployment.md
@@ -1,0 +1,65 @@
+# 10 Blue-Green / Atomic Deployment (verbindlich)
+
+Dieses Dokument definiert das Standard-Deploy-Pattern für nahezu ausfallfreie Releases.
+
+## Ziel
+- Umschalten ohne spürbare Downtime
+- Health-basiertes Cutover
+- Schneller, deterministischer Rollback
+
+## Deploy-Pattern
+- `blue`: aktuell produktive Instanz
+- `green`: neue Kandidaten-Instanz
+- Traffic wird erst nach erfolgreichem Health-Check auf `green` umgeschaltet.
+- Rollback bedeutet reines Zurückschalten auf `blue`.
+
+## Voraussetzungen
+- Reverse Proxy vor App (z. B. NGINX/Traefik/Caddy)
+- Separater Upstream pro Farbe (`blue`, `green`)
+- Health-Endpunkt: `GET /api/system/status`
+- Staging-Gate muss erfolgreich sein (`docs/STAGING_GATE.md`)
+
+## Health-basierter Umschaltpunkt
+`green` gilt als "ready" wenn alle Bedingungen erfüllt sind:
+1. HTTP 200 auf `/api/system/status`
+2. API antwortet stabil für mindestens 30 Sekunden
+3. Basistests gegen `green` erfolgreich (mind. system status + monitor slo)
+
+Erst danach wird der Proxy-Upstream atomar umgeschaltet.
+
+## Referenzablauf (Docker)
+1. `green` deployen (parallel zu `blue`), anderer Service-Name/Port.
+2. Health prüfen:
+```bash
+curl -fsS http://green-host:5000/api/system/status
+curl -fsS http://green-host:5000/api/monitor/slo
+```
+3. Proxy-Konfiguration auf `green` wechseln.
+4. Proxy reloaden (ohne Full-Restart).
+5. Traffic + Fehlerquote 5-15 Minuten beobachten.
+6. `blue` als warmen Fallback noch nicht sofort entfernen.
+
+## Rollback-Prozedur
+Rollback auslösen bei:
+- Fehleranstieg (5xx/Timeouts)
+- kritische Control-Endpunkte instabil
+- funktionale Kernflüsse fehlschlagen
+
+Schritte:
+1. Proxy-Upstream sofort zurück auf `blue`.
+2. Gesundheit von `blue` bestätigen.
+3. Incident eröffnen und `green` isoliert analysieren.
+4. Fehlerbehebung in neuem Build, dann erneutes Green-Deploy.
+
+## Atomicity-Regeln
+- Keine In-Place-Updates des aktiven Containers.
+- Umschaltung nur über Proxy-Target/Service-Alias.
+- Daten-/Schemaänderungen müssen rückwärtskompatibel sein.
+- Irreversible Migrationsschritte erst nach stabiler Green-Phase.
+
+## Minimal-Checklist (Go-Live)
+1. Staging-Gate = GO
+2. Green health = OK
+3. Umschalten durchgeführt
+4. Post-switch Monitoring = OK
+5. Rollback-Plan verifiziert

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ Diese Dateien sind der verbindliche Stand fuer Betrieb, Integration und API:
 - `docs/08_socket_events.md`
 - `docs/ADR/README.md`
 - `docs/09_module_boundaries_ownership.md`
+- `docs/10_blue_green_atomic_deployment.md`
 - `docs/DOCKER_DEPLOYMENT.md`
 - `docs/STAGING_GATE.md`
 - `docs/SECURITY_INCIDENT_SENTRY_DSN.md`

--- a/docs/STAGING_GATE.md
+++ b/docs/STAGING_GATE.md
@@ -7,6 +7,7 @@ Dieses Dokument beschreibt den reproduzierbaren Staging-Gate vor einem Produktiv
 - Risiko vor Prod-Deploy reduzieren
 - Kernflüsse unter stagingnahen Bedingungen prüfen
 - Eindeutige Go/No-Go-Entscheidung erzeugen
+- Übergabe in Blue-Green-Cutover vorbereiten (`docs/10_blue_green_atomic_deployment.md`)
 
 ## Workflow
 


### PR DESCRIPTION
## Summary
- add canonical blue-green/atomic deployment strategy doc
- define health-based cutover criteria and rollback procedure
- document atomicity rules and go-live checklist
- link staging gate with blue-green cutover handoff

## Validation
- `.venv/bin/python scripts/check_api_doc_drift.py`
- `.venv/bin/python scripts/check_openapi_contract_drift.py`

Closes #43
