### PR TITLE
perf(api): caching strategy for hot read endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Für den aktuellen produktiven Ablauf sind diese Dokumente die verbindliche Quel
 - `docs/ADR/README.md`
 - `docs/09_module_boundaries_ownership.md`
 - `docs/10_blue_green_atomic_deployment.md`
+- `docs/11_caching_strategy.md`
 - `docs/WEB_SETUP_ROUTING_ADS_GUIDE.md`
 - `docs/STAGING_GATE.md` (Release-Gates, Canary, Go/No-Go)
 - `docs/SECURITY_INCIDENT_SENTRY_DSN.md` (Incident-Runbook & Secret-Policy)

--- a/docs/11_caching_strategy.md
+++ b/docs/11_caching_strategy.md
@@ -1,0 +1,50 @@
+# 11 Caching Strategy for Read Endpoints (verbindlich)
+
+Dieses Dokument beschreibt die Read-Cache-Strategie für häufig genutzte API-Endpunkte.
+
+## Ziele
+- Antwortzeiten stabilisieren
+- CPU-Last bei Polling-Endpunkten senken
+- Datenkorrektheit durch kurze TTL und Invalidation erhalten
+
+## Hot Endpoints
+- `GET /api/system/status`
+- `GET /api/telemetry`
+- `GET /api/monitor/slo`
+- `GET /api/monitor/streams`
+
+## TTL-Regeln
+- `system/status`: Standard `1.0s`
+- `telemetry`: Standard `0.5s`
+- `monitor/slo`: Standard `1.0s`
+- `monitor/streams`: Standard `1.0s`
+
+Konfiguration über ENV:
+- `SMARTHOME_READ_CACHE_TTL_SECONDS`
+- `SMARTHOME_READ_CACHE_TTL_SYSTEM_STATUS`
+- `SMARTHOME_READ_CACHE_TTL_TELEMETRY`
+- `SMARTHOME_READ_CACHE_TTL_MONITOR_SLO`
+- `SMARTHOME_READ_CACHE_TTL_MONITOR_STREAMS`
+- `SMARTHOME_READ_CACHE_MAX_ENTRIES` (Default `256`)
+
+## Invalidation-Regel
+- Jeder API-Request mit Methode `POST|PUT|PATCH|DELETE` invalidiert den Read-Cache vollständig.
+- Dadurch sind Folge-Reads nach schreibenden Operationen konsistent.
+
+## Beobachtbarkeit
+- Response-Header `X-Read-Cache: HIT|MISS` auf gecachten Endpunkten.
+- Contract-Test sichert Verhalten ab (`test_api_contracts.py`).
+
+## Messung Vor/Nach
+Empfohlene Lastmessung (lokal/staging):
+```bash
+# warm-up
+for i in $(seq 1 50); do curl -s http://127.0.0.1:5000/api/system/status >/dev/null; done
+
+# einfacher Latenzvergleich
+for i in $(seq 1 200); do curl -s -o /dev/null -w "%{time_total}\n" http://127.0.0.1:5000/api/system/status; done
+```
+
+Erwartung:
+- niedrigere Median-/p95-Latenz bei Polling-Last
+- geringere CPU-Spitzen ohne Funktionsverlust

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ Diese Dateien sind der verbindliche Stand fuer Betrieb, Integration und API:
 - `docs/ADR/README.md`
 - `docs/09_module_boundaries_ownership.md`
 - `docs/10_blue_green_atomic_deployment.md`
+- `docs/11_caching_strategy.md`
 - `docs/DOCKER_DEPLOYMENT.md`
 - `docs/STAGING_GATE.md`
 - `docs/SECURITY_INCIDENT_SENTRY_DSN.md`


### PR DESCRIPTION
## Summary
- implement in-memory TTL read cache for hot GET endpoints
- add automatic cache invalidation on state-changing API methods
- add `X-Read-Cache: HIT|MISS` response header for observability
- add contract test for cache hit + invalidation behavior
- add canonical caching strategy doc with TTL and measurement guidance

## Endpoints covered
- `GET /api/system/status`
- `GET /api/telemetry`
- `GET /api/monitor/slo`
- `GET /api/monitor/streams`

## Validation
- `.venv/bin/python -m py_compile modules/gateway/web_manager.py`
- `.venv/bin/python scripts/check_api_doc_drift.py`
- `.venv/bin/python scripts/check_openapi_contract_drift.py`
- `.venv/bin/pytest -q test_api_contracts.py`
- `make smoke`

Closes #31
