### PR TITLE
feat(config): schema-versioned config migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Für den aktuellen produktiven Ablauf sind diese Dokumente die verbindliche Quel
 - `docs/09_module_boundaries_ownership.md`
 - `docs/10_blue_green_atomic_deployment.md`
 - `docs/11_caching_strategy.md`
+- `docs/12_config_migrations.md`
 - `docs/WEB_SETUP_ROUTING_ADS_GUIDE.md`
 - `docs/STAGING_GATE.md` (Release-Gates, Canary, Go/No-Go)
 - `docs/SECURITY_INCIDENT_SENTRY_DSN.md` (Incident-Runbook & Secret-Policy)

--- a/docs/12_config_migrations.md
+++ b/docs/12_config_migrations.md
@@ -1,0 +1,35 @@
+# 12 Config Schema and Migration Policy (verbindlich)
+
+Dieses Dokument beschreibt die Versionsführung für lokale Konfigurationen.
+
+## Ziel
+- sichere Weiterentwicklung von Config-Dateien
+- kontrollierte Migration älterer Installationen
+- klare Validierung vor Nutzung
+
+## Aktuelles Schema
+- Datei: `twincat_config.json`
+- Feld: `schema_version`
+- Aktuelle Version: `2`
+
+## Migrationspfad
+- Legacy ohne `schema_version` wird als Schema `1` behandelt.
+- Migration `1 -> 2` ergänzt/normalisiert u. a.:
+- `widgets` als Objekt
+- `plc.runtime_type` (Default `TC3`)
+- `schema_version=2`, `version=2.0`
+
+## Validierung beim Laden
+- Config muss JSON-Objekt sein.
+- Pflichtstruktur wird validiert (`theme`, `custom_lights`, `widgets`, `plc`).
+- Höhere unbekannte `schema_version` wird abgelehnt (Fail-Closed).
+
+## Schreibregeln
+- Beim Speichern wird immer `schema_version=2` geschrieben.
+- Legacy-Config wird beim Laden migriert und wieder persistiert.
+
+## Tests
+- `test_config_migrations.py` deckt ab:
+- Migration Alt -> Neu
+- Rejection bei Future-Schema
+- Default-Config mit Schema-Version

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ Diese Dateien sind der verbindliche Stand fuer Betrieb, Integration und API:
 - `docs/09_module_boundaries_ownership.md`
 - `docs/10_blue_green_atomic_deployment.md`
 - `docs/11_caching_strategy.md`
+- `docs/12_config_migrations.md`
 - `docs/DOCKER_DEPLOYMENT.md`
 - `docs/STAGING_GATE.md`
 - `docs/SECURITY_INCIDENT_SENTRY_DSN.md`

--- a/test_config_migrations.py
+++ b/test_config_migrations.py
@@ -1,0 +1,56 @@
+import json
+import os
+from pathlib import Path
+
+from modules.core.config_manager import ConfigManager
+
+
+def _write_json(path: Path, payload):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_config_manager_migrates_legacy_schema(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    mgr = ConfigManager()
+    legacy = {
+        "version": "1.0",
+        "theme": "blue",
+        "plc": {"ams_net_id": "1.2.3.4.5.6", "port": 851},
+        "custom_lights": {},
+    }
+    _write_json(Path(mgr.config_file), legacy)
+
+    assert mgr.load_config() is True
+    assert mgr.config.get("schema_version") == 2
+    assert mgr.config.get("version") == "2.0"
+    assert isinstance(mgr.config.get("widgets"), dict)
+    assert mgr.config.get("plc", {}).get("runtime_type") in ("TC2", "TC3")
+
+
+def test_config_manager_rejects_future_schema(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    mgr = ConfigManager()
+    future_cfg = {
+        "schema_version": 99,
+        "version": "99.0",
+        "theme": "blue",
+        "custom_lights": {},
+        "widgets": {},
+    }
+    _write_json(Path(mgr.config_file), future_cfg)
+
+    assert mgr.load_config() is False
+
+
+def test_default_config_has_schema_version(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    mgr = ConfigManager()
+    assert mgr.load_config() is False
+
+    saved = json.loads(Path(mgr.config_file).read_text(encoding="utf-8"))
+    assert saved.get("schema_version") == 2
+    assert saved.get("version") == "2.0"


### PR DESCRIPTION
## Summary
- add `schema_version` based config model in `ConfigManager`
- implement legacy migration path `v1 -> v2`
- add fail-closed validation for unknown future schema versions
- persist migrated configs automatically
- add dedicated migration test suite (`test_config_migrations.py`)
- add canonical documentation for config schema/migrations

## Validation
- `.venv/bin/python -m py_compile modules/core/config_manager.py`
- `.venv/bin/python scripts/check_api_doc_drift.py`
- `.venv/bin/python scripts/check_openapi_contract_drift.py`
- `.venv/bin/pytest -q test_config_migrations.py test_api_contracts.py`
- `make smoke`

Closes #16
