### PR TITLE
feat(frontend): runtime feature flags for risky UI changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Für den aktuellen produktiven Ablauf sind diese Dokumente die verbindliche Quel
 - `docs/10_blue_green_atomic_deployment.md`
 - `docs/11_caching_strategy.md`
 - `docs/12_config_migrations.md`
+- `docs/13_feature_flags_rollout.md`
 - `docs/WEB_SETUP_ROUTING_ADS_GUIDE.md`
 - `docs/STAGING_GATE.md` (Release-Gates, Canary, Go/No-Go)
 - `docs/SECURITY_INCIDENT_SENTRY_DSN.md` (Incident-Runbook & Secret-Policy)

--- a/docs/05_api_reference.md
+++ b/docs/05_api_reference.md
@@ -26,6 +26,7 @@ Nur hier gelistete Endpunkte gelten als dokumentierter API-Stand.
 - `GET /api/system/status`
 - `GET /api/system/dependencies`
 - `GET /api/system/versioning`
+- `GET /api/system/feature-flags`
 - `GET /api/telemetry`
 
 ## PLC / TwinCAT
@@ -80,6 +81,7 @@ Nur hier gelistete Endpunkte gelten als dokumentierter API-Stand.
 - `GET /api/admin/service/info`
 - `POST /api/admin/service/restart`
 - `POST /api/admin/service/restart-daemon`
+- `POST /api/admin/feature-flags`
 
 ## Monitoring
 - `GET /api/monitor/dataflow`

--- a/docs/13_feature_flags_rollout.md
+++ b/docs/13_feature_flags_rollout.md
@@ -1,0 +1,39 @@
+# 13 Feature Flags Rollout/Rollback (verbindlich)
+
+Dieses Dokument beschreibt den Einsatz von UI-Feature-Flags für riskante Änderungen.
+
+## Ziel
+- neue UI-Funktionen ohne Redeploy aktivieren/deaktivieren
+- kontrollierter Rollout und schneller Rollback
+
+## API
+- Lesen: `GET /api/system/feature-flags`
+- Aktualisieren: `POST /api/admin/feature-flags`
+
+## Payload
+```json
+{
+  "flags": {
+    "ui.page.camera-wall": true,
+    "ui.page.monitor": true,
+    "ui.page.admin": true,
+    "ui.ring.webrtc": true
+  }
+}
+```
+
+## Laufzeitverhalten
+- Flags werden im Frontend zur Laufzeit geladen.
+- Deaktivierte Seiten werden in der Navigation ausgeblendet.
+- Ein Aufruf deaktivierter Seiten fällt auf Dashboard zurück.
+- Ring WebRTC wird über `ui.ring.webrtc` hart abschaltbar.
+
+## Rollout-Vorgehen
+1. Feature default `false` lassen.
+2. In Staging aktivieren und beobachten.
+3. In Prod schrittweise aktivieren.
+4. Bei Fehlern sofort per Flag zurück auf `false`.
+
+## Rollback
+- API-Update mit betroffenen Flags auf `false`.
+- Kein Redeploy notwendig.

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ Diese Dateien sind der verbindliche Stand fuer Betrieb, Integration und API:
 - `docs/10_blue_green_atomic_deployment.md`
 - `docs/11_caching_strategy.md`
 - `docs/12_config_migrations.md`
+- `docs/13_feature_flags_rollout.md`
 - `docs/DOCKER_DEPLOYMENT.md`
 - `docs/STAGING_GATE.md`
 - `docs/SECURITY_INCIDENT_SENTRY_DSN.md`

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -20,6 +20,51 @@
     }
   ],
   "paths": {
+    "/api/admin/feature-flags": {
+      "post": {
+        "operationId": "post_api_admin_feature_flags",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericJson"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenericJson"
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/admin/logs": {
       "get": {
         "operationId": "get_api_admin_logs",
@@ -1921,6 +1966,41 @@
     "/api/system/dependencies": {
       "get": {
         "operationId": "get_api_system_dependencies",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericJson"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      }
+    },
+    "/api/system/feature-flags": {
+      "get": {
+        "operationId": "get_api_system_feature_flags",
         "responses": {
           "200": {
             "description": "Successful response",

--- a/test_api_contracts.py
+++ b/test_api_contracts.py
@@ -145,6 +145,29 @@ def test_contract_api_versioning_policy_endpoint(web_fixture):
     assert isinstance(payload["deprecated_endpoints"], list)
 
 
+def test_contract_feature_flags_read_and_update(web_fixture):
+    _, client = web_fixture
+    get_first = client.get("/api/system/feature-flags")
+    assert get_first.status_code == 200
+    first_payload = get_first.get_json()
+    assert first_payload["success"] is True
+    assert isinstance(first_payload["flags"], dict)
+
+    update = client.post(
+        "/api/admin/feature-flags",
+        json={"flags": {"ui.page.monitor": False}}
+    )
+    assert update.status_code == 200
+    update_payload = update.get_json()
+    assert update_payload["success"] is True
+    assert update_payload["flags"]["ui.page.monitor"] is False
+
+    get_second = client.get("/api/system/feature-flags")
+    assert get_second.status_code == 200
+    second_payload = get_second.get_json()
+    assert second_payload["flags"]["ui.page.monitor"] is False
+
+
 def test_contract_error_code_for_missing_variable(web_fixture):
     _, client = web_fixture
     res = client.post("/api/variables/write", json={"plc_id": "plc_001", "value": True})


### PR DESCRIPTION
## Summary
- add runtime feature-flag API endpoints:
  - `GET /api/system/feature-flags`
  - `POST /api/admin/feature-flags`
- add file-backed feature-flag persistence in backend (`config/feature_flags.json`)
- add frontend flag loader + page gating/fallback behavior
- add Ring WebRTC kill-switch via `ui.ring.webrtc`
- update API docs/OpenAPI and add rollout/rollback feature-flag guide
- add contract test for feature-flag read/update flow

## Validation
- `.venv/bin/python scripts/generate_openapi_contract.py`
- `.venv/bin/python -m py_compile modules/gateway/web_manager.py`
- `.venv/bin/python scripts/check_api_doc_drift.py`
- `.venv/bin/python scripts/check_openapi_contract_drift.py`
- `.venv/bin/pytest -q test_api_contracts.py`
- `make smoke`

Closes #23
