### PR TITLE
ux: consistent notifications and recovery actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Für den aktuellen produktiven Ablauf sind diese Dokumente die verbindliche Quel
 - `docs/11_caching_strategy.md`
 - `docs/12_config_migrations.md`
 - `docs/13_feature_flags_rollout.md`
+- `docs/14_ux_notifications.md`
+- `docs/15_error_recovery_actions.md`
 - `docs/WEB_SETUP_ROUTING_ADS_GUIDE.md`
 - `docs/STAGING_GATE.md` (Release-Gates, Canary, Go/No-Go)
 - `docs/SECURITY_INCIDENT_SENTRY_DSN.md` (Incident-Runbook & Secret-Policy)

--- a/docs/14_ux_notifications.md
+++ b/docs/14_ux_notifications.md
@@ -1,0 +1,23 @@
+# 14 UX Notification Strategy (verbindlich)
+
+Dieses Dokument definiert die konsistente Notification-Strategie im Frontend.
+
+## Ziele
+- einheitliches Feedback statt verstreuter Browser-`alert()`-Dialoge
+- nicht-blockierende Nutzerführung
+- klare Semantik nach Schweregrad
+
+## Notification-Typen
+- `info`: neutraler Zustand/Hinweis
+- `success`: erfolgreich abgeschlossene Aktion
+- `error`: Fehlerzustand mit optionaler Recovery-Aktion
+
+## Implementierung
+- zentral über `showToast(message, { level, duration, actions })`
+- Container: `#app-toast-container`
+- max. 2 Aktionen pro Toast (z. B. Retry, Navigation)
+
+## UX-Regeln
+- keine modalen Alerts für normale Betriebsfehler
+- Erfolgsmeldungen kurz und selbstschließend
+- Fehler länger sichtbar und mit Recovery-Buttons

--- a/docs/15_error_recovery_actions.md
+++ b/docs/15_error_recovery_actions.md
@@ -1,0 +1,19 @@
+# 15 Error States with Recovery Actions (verbindlich)
+
+Dieses Dokument beschreibt, wie Fehlerzustände mit klaren nächsten Schritten dargestellt werden.
+
+## Prinzip
+Jeder relevante Laufzeitfehler soll mindestens eine direkte Recovery-Option anbieten.
+
+## Recovery-Muster
+- `Erneut versuchen`: gleiche Aktion erneut ausführen
+- `Zu Setup`: Nutzer auf passende Konfigurationsseite führen
+
+## Aktuell abgedeckte Flüsse
+- Laden System-Status:
+- Fehler-Toast mit `Erneut versuchen` und `Zu Setup`
+- PLC verbinden/trennen:
+- Fehler-Toast mit Recovery-Aktionen
+
+## Erweiterungsregel
+Neue riskante Flows müssen vor Merge ein Recovery-Muster implementieren.

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,8 @@ Diese Dateien sind der verbindliche Stand fuer Betrieb, Integration und API:
 - `docs/11_caching_strategy.md`
 - `docs/12_config_migrations.md`
 - `docs/13_feature_flags_rollout.md`
+- `docs/14_ux_notifications.md`
+- `docs/15_error_recovery_actions.md`
 - `docs/DOCKER_DEPLOYMENT.md`
 - `docs/STAGING_GATE.md`
 - `docs/SECURITY_INCIDENT_SENTRY_DSN.md`


### PR DESCRIPTION
## Summary
- add central toast notification system in frontend (`showToast`)
- add recoverable error helper with explicit actions (`Erneut versuchen`, `Zu Setup`)
- wire recoverable UX for system status loading and PLC connect/disconnect failures
- replace feature-page-disabled blocking alert with toast fallback
- add canonical UX docs for notification strategy and error recovery actions

## Validation
- `node --check web/static/js/app.js`
- `.venv/bin/python scripts/check_api_doc_drift.py`
- `.venv/bin/python scripts/check_openapi_contract_drift.py`
- `make smoke`

Closes #45
Closes #35
