### PR TITLE
perf(frontend): bundle/load-time optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Für den aktuellen produktiven Ablauf sind diese Dokumente die verbindliche Quel
 - `docs/13_feature_flags_rollout.md`
 - `docs/14_ux_notifications.md`
 - `docs/15_error_recovery_actions.md`
+- `docs/16_frontend_performance.md`
 - `docs/WEB_SETUP_ROUTING_ADS_GUIDE.md`
 - `docs/STAGING_GATE.md` (Release-Gates, Canary, Go/No-Go)
 - `docs/SECURITY_INCIDENT_SENTRY_DSN.md` (Incident-Runbook & Secret-Policy)

--- a/docs/16_frontend_performance.md
+++ b/docs/16_frontend_performance.md
@@ -1,0 +1,28 @@
+# 16 Frontend Load Performance Strategy (verbindlich)
+
+Dieses Dokument beschreibt die aktuelle Strategie zur Reduktion der Initial-Ladezeit.
+
+## Maßnahmen
+- `defer` für lokale JS-Bundles (`socket_handler.js`, `variable-manager.js`, `app.js`)
+- nicht-kritische Boot-Aufgaben via `requestIdleCallback`:
+- Socket-Init
+- Systemstatus-Laden
+- opt-in Dev-Test-Szenarien
+- Dev-Testbundle (`test_scenarios.js`) wird nicht mehr standardmäßig geladen
+
+## Code-Splitting-Ansatz
+- risikoreiche/diagnostische Funktionen werden opt-in nachgeladen
+- Heavy-Seitenlogik bleibt page-getrieben (Load on navigation)
+
+## Messung (Before/After)
+1. Browser DevTools > Performance/Lighthouse (Desktop + Mobile Profil)
+2. Kennzahlen erfassen:
+- FCP (First Contentful Paint)
+- LCP (Largest Contentful Paint)
+- TTI/INP
+3. Vergleich unter identischen Bedingungen mit/ohne Warm-Cache
+
+## Erwarteter Effekt
+- schnellerer First-Paint durch verschobene Non-Critical Work
+- weniger JS-Kosten im initialen Parse/Execute-Pfad
+- bessere Reaktionsfähigkeit direkt nach Seitenaufbau

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ Diese Dateien sind der verbindliche Stand fuer Betrieb, Integration und API:
 - `docs/13_feature_flags_rollout.md`
 - `docs/14_ux_notifications.md`
 - `docs/15_error_recovery_actions.md`
+- `docs/16_frontend_performance.md`
 - `docs/DOCKER_DEPLOYMENT.md`
 - `docs/STAGING_GATE.md`
 - `docs/SECURITY_INCIDENT_SENTRY_DSN.md`

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1382,17 +1382,14 @@
     <!-- ================================================================
          JAVASCRIPT
          ================================================================ -->
-    <script src="/static/js/socket_handler.js"></script>
-    <script src="/static/js/variable-manager.js"></script> <!-- ⭐ v5.1.0 -->
-    <script src="/static/js/app.js"></script>
-
-    <!-- Test-Suite (nur im Development-Modus) -->
-    <script src="/static/js/test_scenarios.js"></script>
+    <script defer src="/static/js/socket_handler.js"></script>
+    <script defer src="/static/js/variable-manager.js"></script> <!-- ⭐ v5.1.0 -->
+    <script defer src="/static/js/app.js"></script>
 
     <!-- Lucide Icons initialisieren -->
     <script>
-        // Warte auf vollständiges Laden inkl. Lucide-Library
-        window.addEventListener('load', () => {
+        // Icons nach DOM-Initialisierung aufbauen.
+        window.addEventListener('DOMContentLoaded', () => {
             if (typeof lucide !== 'undefined') {
                 lucide.createIcons();
                 console.log('✅ Lucide Icons initialisiert');


### PR DESCRIPTION
## Summary
- defer local frontend scripts to reduce main-thread pressure on first paint
- move non-critical boot work (`socket`, `system status`) to idle phase
- make dev test scenarios opt-in lazy load (no default production payload)
- keep dashboard rendering on first animation frame
- add canonical frontend performance strategy + measurement doc

## Validation
- `node --check web/static/js/app.js`
- `.venv/bin/python scripts/check_api_doc_drift.py`
- `.venv/bin/python scripts/check_openapi_contract_drift.py`
- `make smoke`

Closes #41
