### PR TITLE
feat(ui): dynamic rooms/pages, kiosk panel mode and version bump v4.6.0

### DIFF
--- a/docs/05_api_reference.md
+++ b/docs/05_api_reference.md
@@ -71,6 +71,19 @@ Nur hier gelistete Endpunkte gelten als dokumentierter API-Stand.
 - `GET /api/camera-triggers/export`
 - `POST /api/camera-triggers/import`
 
+## Widgets / UI Layout
+- `GET /api/widgets`
+- `POST /api/widgets`
+- `PUT /api/widgets/<widget_id>`
+- `DELETE /api/widgets/<widget_id>`
+- `GET /api/pages`
+- `POST /api/pages`
+- `PUT /api/pages/<page_id>`
+- `DELETE /api/pages/<page_id>`
+- `POST /api/pages/reorder`
+- `GET /api/ui-settings`
+- `PUT /api/ui-settings`
+
 ## Admin
 - `GET /api/admin/plcs`
 - `POST /api/admin/plcs`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🚀 Added
 
+#### Räume/Seiten & Panel-Modus (UX)
+- **Neue API**: `GET/POST /api/pages`, `PUT/DELETE /api/pages/<page_id>`, `POST /api/pages/reorder`
+  - Persistente Raum-/Seitenverwaltung inkl. Sortierreihenfolge.
+  - Datei: `modules/gateway/web_manager.py`
+- **Neue API**: `GET/PUT /api/ui-settings`
+  - Persistente Panel-Einstellungen (`default_page`, `kiosk_default`).
+  - Datei: `modules/gateway/web_manager.py`
+- **Widgets-Seite erweitert**:
+  - Raumverwaltung (anlegen, bearbeiten, löschen, sortieren per Drag&Drop und Up/Down)
+  - Panel-Einstellungen (Startseite, Kiosk-Default)
+  - Dateien: `web/templates/index.html`, `web/static/js/app.js`
+- **Navigation erweitert**:
+  - Dynamische Raum-Navigation im Sidebar-Menü
+  - Dynamische Seitenerzeugung im Frontend für neue Räume
+  - Dateien: `web/templates/index.html`, `web/static/js/app.js`
+- **Kiosk-/Vollbild-Bedienung**:
+  - Vollbild-Button für Desktop/Mobile Header
+  - Kiosk-Mode-Toggle (UI-Chrome ausblendbar)
+  - Dateien: `web/templates/index.html`, `web/static/js/app.js`
+
 #### Ring Live Policy & Gateway-Parametrisierung
 - **Neue API**: `GET/POST /api/gateway/ring-live-settings`
   - Datei: `modules/gateway/web_manager.py`
@@ -55,6 +75,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Doppelter Start von RTSP-Streams beim Laden der Kameraseite entfernt.
 - Snapshot blendet Loading-Overlay unmittelbar nach erstem Bild aus.
   - Datei: `web/static/js/app.js`
+
+#### Widget-Editor UX
+- Widgets rendern in dedizierten dynamischen Seiten-Containern statt absolutem Overlay.
+- Widget-Liste gruppiert nach Seite inkl. persistenter Sortierung (`position.order`).
+- Lock/Fixieren pro Widget und Icon-Picker mit Live-Vorschau.
+- Legacy/hardcodierte Demo-Bereiche werden ausgeblendet, sobald echte Widgets für die Seite existieren.
+  - Dateien: `web/static/js/app.js`, `web/templates/index.html`
 
 #### Service-Start & Deployment
 - `web_server_ctl.sh` robuster beim PID-Matching (keine Fehl-Erkennung mehr).

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1307,6 +1307,227 @@
         }
       }
     },
+    "/api/pages": {
+      "get": {
+        "operationId": "get_api_pages",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericJson"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "post": {
+        "operationId": "post_api_pages",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericJson"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenericJson"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/pages/reorder": {
+      "post": {
+        "operationId": "post_api_pages_reorder",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericJson"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenericJson"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/pages/{page_id}": {
+      "delete": {
+        "operationId": "delete_api_pages_page_id",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericJson"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "page_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "put": {
+        "operationId": "put_api_pages_page_id",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericJson"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "page_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenericJson"
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/plc/ads/route/add": {
       "post": {
         "operationId": "post_api_plc_ads_route_add",
@@ -2138,6 +2359,84 @@
         }
       }
     },
+    "/api/ui-settings": {
+      "get": {
+        "operationId": "get_api_ui_settings",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericJson"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "put": {
+        "operationId": "put_api_ui_settings",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericJson"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenericJson"
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/variables/read": {
       "post": {
         "operationId": "post_api_variables_read",
@@ -2286,6 +2585,182 @@
             "$ref": "#/components/responses/InternalError"
           }
         },
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenericJson"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/widgets": {
+      "get": {
+        "operationId": "get_api_widgets",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericJson"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        }
+      },
+      "post": {
+        "operationId": "post_api_widgets",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericJson"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GenericJson"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/widgets/{widget_id}": {
+      "delete": {
+        "operationId": "delete_api_widgets_widget_id",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericJson"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "widget_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "put": {
+        "operationId": "put_api_widgets_widget_id",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenericJson"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          }
+        },
+        "parameters": [
+          {
+            "name": "widget_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "required": false,
           "content": {

--- a/start_web_hmi.py
+++ b/start_web_hmi.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-SmartHome OS v4.5.3 - Web-HMI Starter
+SmartHome OS v4.6.0 - Web-HMI Starter
 Startet das Web-Interface fuer iPhone/Tablet/Desktop
 
 Usage:
@@ -27,7 +27,7 @@ def main():
     args = parser.parse_args()
 
     # ========================================================================
-    # LOGGING SETUP (v4.5.3 + Sentry)
+    # LOGGING SETUP (v4.6.0 + Sentry)
     # ========================================================================
     from modules.core.database_logger import DatabaseLogger
 
@@ -55,7 +55,7 @@ def main():
         print(f"  [WARNING] Sentry-Initialisierung fehlgeschlagen: {e}")
 
     print("=" * 60)
-    print("SmartHome OS v4.5.3 - Web-HMI")
+    print("SmartHome OS v4.6.0 - Web-HMI")
     print("=" * 60)
     print()
 

--- a/web/static/js/widget-manager-v5.js
+++ b/web/static/js/widget-manager-v5.js
@@ -430,14 +430,17 @@ class WidgetManagerV5 {
         document.getElementById('widget-plc-type').value = valueBinding.plc_type || 'BOOL';
         document.getElementById('widget-icon').value = widget.config?.icon || '';
 
-        modal?.classList.remove('hidden');
-        modal?.dataset.editId = widgetId;
+        if (modal) {
+            modal.classList.remove('hidden');
+            modal.dataset.editId = widgetId;
+        }
     }
 
     closeModal() {
         const modal = document.getElementById('widget-modal');
-        modal?.classList.add('hidden');
-        delete modal?.dataset.editId;
+        if (!modal) return;
+        modal.classList.add('hidden');
+        delete modal.dataset.editId;
     }
 
     async saveWidget() {

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -6,7 +6,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="mobile-web-app-capable" content="yes">
-    <title>SmartHome OS v4.5</title>
+    <title>SmartHome OS v4.6.0</title>
 
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='0.9em' font-size='90'>🏠</text></svg>">
@@ -35,6 +35,15 @@
     <style>
         .page { display: none; }
         .page.active { display: block; }
+        body.kiosk-mode aside,
+        body.kiosk-mode header,
+        body.kiosk-mode nav.fixed.bottom-0 {
+            display: none !important;
+        }
+        body.kiosk-mode main {
+            margin-left: 0 !important;
+            padding-bottom: 0 !important;
+        }
     </style>
 </head>
 <body class="bg-gray-50 dark:bg-gray-900 transition-colors duration-200">
@@ -51,7 +60,7 @@
                 </div>
                 <div>
                     <h1 class="text-lg font-bold text-gray-900 dark:text-white">SmartHome</h1>
-                    <p class="text-xs text-gray-500 dark:text-gray-400">OS v4.5</p>
+                    <p class="text-xs text-gray-500 dark:text-gray-400">OS v4.6.0</p>
                 </div>
             </div>
         </div>
@@ -98,6 +107,10 @@
                 <i data-lucide="shield" class="w-5 h-5"></i>
                 <span>Admin</span>
             </a>
+            <div class="pt-3 mt-2 border-t border-gray-200 dark:border-gray-700">
+                <p class="px-4 pb-2 text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">Räume</p>
+                <div id="nav-dynamic-pages" class="space-y-1"></div>
+            </div>
         </nav>
 
         <!-- Footer -->
@@ -107,9 +120,17 @@
                     <div id="sidebar-status" class="w-2 h-2 rounded-full bg-gray-400"></div>
                     <span class="text-xs text-gray-600 dark:text-gray-400">Getrennt</span>
                 </div>
-                <button id="theme-toggle-sidebar" class="theme-toggle p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">
-                    <i data-lucide="sun" class="w-4 h-4"></i>
-                </button>
+                <div class="flex items-center space-x-1">
+                    <button id="kiosk-toggle-sidebar" class="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700" title="Kiosk-Modus">
+                        <i data-lucide="panel-top-close" class="w-4 h-4"></i>
+                    </button>
+                    <button id="fullscreen-toggle-sidebar" class="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700" title="Vollbild">
+                        <i data-lucide="maximize" class="w-4 h-4"></i>
+                    </button>
+                    <button id="theme-toggle-sidebar" class="theme-toggle p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">
+                        <i data-lucide="sun" class="w-4 h-4"></i>
+                    </button>
+                </div>
             </div>
         </div>
     </aside>
@@ -129,16 +150,26 @@
                     <i data-lucide="menu" class="w-6 h-6"></i>
                 </button>
                 <h2 id="page-title-mobile" class="font-semibold text-gray-900 dark:text-white">Dashboard</h2>
-                <button id="theme-toggle-mobile" class="theme-toggle p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">
-                    <i data-lucide="sun" class="w-5 h-5"></i>
-                </button>
+                <div class="flex items-center space-x-1">
+                    <button id="kiosk-toggle-mobile" class="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700" title="Kiosk-Modus">
+                        <i data-lucide="panel-top-close" class="w-5 h-5"></i>
+                    </button>
+                    <button id="fullscreen-toggle-mobile" class="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700" title="Vollbild">
+                        <i data-lucide="maximize" class="w-5 h-5"></i>
+                    </button>
+                    <button id="theme-toggle-mobile" class="theme-toggle p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700">
+                        <i data-lucide="sun" class="w-5 h-5"></i>
+                    </button>
+                </div>
             </div>
         </header>
 
         <!-- Dashboard Page -->
         <div id="dashboard-page" class="page page-container active p-6">
             <h1 class="text-2xl font-bold text-gray-900 dark:text-white mb-6 hidden md:block">Dashboard</h1>
+            <div id="dashboard-widgets-dynamic" class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 mb-6"></div>
 
+            <div data-legacy-page="dashboard">
             <!-- Stats Cards -->
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
                 <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
@@ -200,29 +231,39 @@
                     </button>
                 </div>
             </div>
+            </div>
         </div>
 
         <!-- Lighting Page -->
         <div id="lighting-page" class="page page-container p-6">
             <h1 class="text-2xl font-bold text-gray-900 dark:text-white mb-6 hidden md:block">Beleuchtung</h1>
+            <div id="lighting-widgets-dynamic" class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 mb-6"></div>
+            <div data-legacy-page="lighting">
             <div id="lighting-grid" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                 <p class="text-gray-500">Lade Lichter...</p>
+            </div>
             </div>
         </div>
 
         <!-- Climate Page -->
         <div id="climate-page" class="page page-container p-6">
             <h1 class="text-2xl font-bold text-gray-900 dark:text-white mb-6 hidden md:block">Klima</h1>
+            <div id="climate-widgets-dynamic" class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 mb-6"></div>
+            <div data-legacy-page="climate">
             <div id="climate-grid" class="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <p class="text-gray-500">Lade Klimadaten...</p>
+            </div>
             </div>
         </div>
 
         <!-- Energy Page -->
         <div id="energy-page" class="page page-container p-6">
             <h1 class="text-2xl font-bold text-gray-900 dark:text-white mb-6 hidden md:block">Energie</h1>
+            <div id="energy-widgets-dynamic" class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 mb-6"></div>
+            <div data-legacy-page="energy">
             <div id="energy-grid" class="space-y-4">
                 <p class="text-gray-500">Lade Energiedaten...</p>
+            </div>
             </div>
         </div>
 
@@ -1063,6 +1104,44 @@
                     <!-- Wird dynamisch gefüllt -->
                 </div>
             </div>
+
+            <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6 mb-6">
+                <div class="flex items-center justify-between mb-4">
+                    <h2 class="text-lg font-semibold text-gray-900 dark:text-white">Seiten / Räume</h2>
+                    <div class="flex items-center space-x-2">
+                        <input id="new-room-name" type="text" placeholder="z.B. EG Flur"
+                            class="px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white">
+                        <input id="new-room-icon" type="text" placeholder="Icon"
+                            class="w-28 px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white">
+                        <button id="add-room-btn" class="px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700">
+                            <i data-lucide="plus" class="w-4 h-4 inline mr-1"></i> Seite
+                        </button>
+                    </div>
+                </div>
+                <div id="room-list" class="space-y-2"></div>
+            </div>
+
+            <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6 mb-6">
+                <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">Panel-Modus</h2>
+                <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+                    <div>
+                        <label class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">Startseite</label>
+                        <select id="panel-start-page"
+                            class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"></select>
+                    </div>
+                    <div class="flex items-end">
+                        <label class="inline-flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+                            <input id="panel-kiosk-default" type="checkbox" class="rounded">
+                            Kiosk standardmäßig aktiv
+                        </label>
+                    </div>
+                    <div class="flex items-end">
+                        <button id="save-panel-settings-btn" class="w-full px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700">
+                            <i data-lucide="save" class="w-4 h-4 inline mr-1"></i> Panel-Einstellungen speichern
+                        </button>
+                    </div>
+                </div>
+            </div>
         </div>
 
         <!-- Widget Editor Modal (versteckt) -->
@@ -1097,6 +1176,18 @@
                         </div>
 
                         <div>
+                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Icon</label>
+                            <div class="flex items-center space-x-2">
+                                <input type="text" id="widget-icon" placeholder="z.B. lightbulb"
+                                    class="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white">
+                                <div id="widget-icon-preview" class="w-10 h-10 rounded-lg bg-gray-100 dark:bg-gray-700 flex items-center justify-center">
+                                    <i data-lucide="box" class="w-5 h-5 text-gray-500"></i>
+                                </div>
+                            </div>
+                            <div id="widget-icon-quickpick" class="mt-2 flex flex-wrap gap-2"></div>
+                        </div>
+
+                        <div>
                             <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Seite</label>
                             <select id="widget-page" required
                                 class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white">
@@ -1104,7 +1195,23 @@
                                 <option value="lighting">Beleuchtung</option>
                                 <option value="climate">Klima</option>
                                 <option value="energy">Energie</option>
+                                <option value="cameras">Kameras</option>
+                                <option value="monitor">Monitor</option>
+                                <option value="widgets">Widgets</option>
                             </select>
+                        </div>
+
+                        <div class="flex items-center justify-between p-3 rounded-lg bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700">
+                            <div>
+                                <p class="text-sm font-medium text-gray-800 dark:text-gray-200">Widget fixieren</p>
+                                <p class="text-xs text-gray-500 dark:text-gray-400">Fixierte Widgets werden bei der Sortierung nicht verschoben.</p>
+                            </div>
+                            <label class="inline-flex items-center cursor-pointer">
+                                <input id="widget-locked" type="checkbox" class="sr-only peer">
+                                <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none rounded-full peer dark:bg-gray-700 peer-checked:bg-blue-600 relative">
+                                    <span class="absolute top-0.5 left-0.5 bg-white w-5 h-5 rounded-full transition-transform peer-checked:translate-x-5"></span>
+                                </div>
+                            </label>
                         </div>
 
                         <!-- Variable Bindings Section -->


### PR DESCRIPTION
## Summary
- add dynamic rooms/pages management with persistence (`/api/pages`, reorder, update/delete)
- add panel UI settings with persistence (`/api/ui-settings`)
- add fullscreen + kiosk mode controls for panel usage
- extend widget editor UX: icon picker, lock/fix, per-page ordering, legacy widget fallback handling
- add room management UI in Widgets page (create/edit/delete/reorder/open)
- bump visible website version to `v4.6.0` and starter banner to `v4.6.0`
- update API reference + regenerate `docs/openapi.json`

## Validation
- `node --check web/static/js/app.js`
- `node --check web/static/js/widget-manager-v5.js`
- `python3 -m py_compile modules/gateway/web_manager.py`
- `python3 scripts/check_api_doc_drift.py`
- `python3 scripts/check_openapi_contract_drift.py`

## Notes
- `WebManager.VERSION` bumped to `1.1.0` (non-breaking API additions under `/api` major v1).