### PR TITLE
Polish camera page layout and tile ordering

### DIFF
--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -278,6 +278,10 @@ class SmartHomeApp {
 
                 return response;
             } catch (e) {
+                // Snapshot/timeouts intentionally use AbortController; don't log those as auth noise.
+                if (e && (e.name === 'AbortError' || String(e).includes('signal is aborted'))) {
+                    return originalFetch(input, init);
+                }
                 console.warn('API-Key Injection übersprungen:', e);
                 return originalFetch(input, init);
             }

--- a/web/static/js/camera-page-ui.js
+++ b/web/static/js/camera-page-ui.js
@@ -1,4 +1,6 @@
 (function () {
+    const RING_EVENTS_CARD_ID = '__ring_events__';
+
     const cameraPageUiMethods = {
         async loadCamerasPage() {
             console.log('📹 Lade Kameras...');
@@ -23,11 +25,6 @@
             const ringAuthBtn = document.getElementById('ring-auth-btn');
             if (ringAuthBtn) this._bindScopedListener(ringAuthBtn, 'click', () => this._ringAuthenticateFromForm(), { scope, key: 'cameras:ring-auth' });
 
-            const refreshRingEventsBtn = document.getElementById('refresh-ring-events-btn');
-            if (refreshRingEventsBtn) {
-                this._bindScopedListener(refreshRingEventsBtn, 'click', () => this.loadRingEvents(), { scope, key: 'cameras:ring-events-refresh' });
-            }
-
             const ringWebrtcPreferred = document.getElementById('ring-webrtc-preferred');
             if (ringWebrtcPreferred) {
                 const stored = localStorage.getItem('ringWebrtcPreferred');
@@ -38,8 +35,14 @@
             }
 
             this._refreshRingStatus();
+            await this.loadSavedCameras();
+
+            const refreshRingEventsBtn = document.getElementById('refresh-ring-events-btn');
+            if (refreshRingEventsBtn) {
+                this._bindScopedListener(refreshRingEventsBtn, 'click', () => this.loadRingEvents(), { scope, key: 'cameras:ring-events-refresh' });
+            }
+
             this.loadRingEvents();
-            this.loadSavedCameras();
         },
 
         _getScanOptions() {
@@ -59,6 +62,88 @@
             const user = document.getElementById('scan-user')?.value?.trim() || 'admin';
             const password = document.getElementById('scan-password')?.value?.trim() || 'admin';
             return { ports, user, password };
+        },
+
+        _getCameraGridOrder() {
+            try {
+                const raw = localStorage.getItem('cameraGridOrder');
+                const parsed = raw ? JSON.parse(raw) : [];
+                return Array.isArray(parsed) ? parsed.filter(id => typeof id === 'string' && id) : [];
+            } catch (e) {
+                return [];
+            }
+        },
+
+        _setCameraGridOrder(order) {
+            if (!Array.isArray(order)) return;
+            localStorage.setItem('cameraGridOrder', JSON.stringify(order.filter(id => typeof id === 'string' && id)));
+        },
+
+        _sortCameraGridIds(camIds) {
+            const preferred = this._getCameraGridOrder();
+            const available = [RING_EVENTS_CARD_ID, ...camIds];
+            const known = preferred.filter(id => available.includes(id));
+            const rest = available.filter(id => !known.includes(id));
+            return [...known, ...rest];
+        },
+
+        _setupCameraGridDragAndDrop() {
+            const grid = document.getElementById('cameras-grid');
+            if (!grid) return;
+
+            let draggingId = null;
+
+            const persistOrder = () => {
+                const order = Array.from(grid.querySelectorAll('.camera-card[data-card-id]'))
+                    .map(card => card.getAttribute('data-card-id'))
+                    .filter(Boolean);
+                this._setCameraGridOrder(order);
+            };
+
+            grid.querySelectorAll('.camera-card[data-card-id]').forEach(card => {
+                const cardId = card.getAttribute('data-card-id');
+                card.setAttribute('draggable', 'true');
+
+                card.addEventListener('dragstart', (e) => {
+                    draggingId = cardId;
+                    card.classList.add('opacity-60', 'scale-[0.98]');
+                    if (e.dataTransfer) {
+                        e.dataTransfer.effectAllowed = 'move';
+                        e.dataTransfer.setData('text/plain', cardId);
+                    }
+                });
+
+                card.addEventListener('dragend', () => {
+                    draggingId = null;
+                    card.classList.remove('opacity-60', 'scale-[0.98]');
+                    grid.querySelectorAll('.camera-card').forEach(item => {
+                        item.classList.remove('ring-2', 'ring-blue-400', 'ring-offset-2', 'dark:ring-offset-gray-900');
+                    });
+                });
+
+                card.addEventListener('dragover', (e) => {
+                    if (!draggingId || draggingId === cardId) return;
+                    e.preventDefault();
+                    card.classList.add('ring-2', 'ring-blue-400', 'ring-offset-2', 'dark:ring-offset-gray-900');
+                });
+
+                card.addEventListener('dragleave', () => {
+                    card.classList.remove('ring-2', 'ring-blue-400', 'ring-offset-2', 'dark:ring-offset-gray-900');
+                });
+
+                card.addEventListener('drop', (e) => {
+                    if (!draggingId || draggingId === cardId) return;
+                    e.preventDefault();
+                    const dragged = grid.querySelector(`.camera-card[data-card-id="${draggingId}"]`);
+                    if (!dragged || dragged === card) return;
+
+                    const rect = card.getBoundingClientRect();
+                    const before = e.clientY < rect.top + rect.height / 2;
+                    card.parentNode.insertBefore(dragged, before ? card : card.nextSibling);
+                    persistOrder();
+                    card.classList.remove('ring-2', 'ring-blue-400', 'ring-offset-2', 'dark:ring-offset-gray-900');
+                });
+            });
         },
 
         async _runNetworkScan() {
@@ -326,6 +411,7 @@
             }
 
             const camIds = Object.keys(cameras);
+            console.log(`Kameras geladen: ${camIds.length}`, camIds);
             this._clearRtspSnapshotTimers();
             this._clearRingSnapshotTimers();
             for (const timer of Object.values(this._hlsRetryTimers)) {
@@ -456,16 +542,51 @@
                 }
             }
 
+            const orderedIds = this._sortCameraGridIds(camIds);
             let gridHtml = '';
-            camIds.forEach(camId => {
+            orderedIds.forEach(cardId => {
+                if (cardId === RING_EVENTS_CARD_ID) {
+                    gridHtml += `
+                <div class="bg-white/95 dark:bg-gray-800/95 rounded-2xl border border-gray-200/80 dark:border-gray-700 shadow-sm hover:shadow-lg hover:-translate-y-0.5 p-4 camera-card transition-transform transition-shadow duration-200" data-cam-type="ring-events" data-card-id="${RING_EVENTS_CARD_ID}">
+                    <div class="flex items-start justify-between gap-3 mb-3">
+                        <div>
+                            <div class="flex items-center gap-2">
+                                <button class="camera-card-drag-handle p-1.5 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-500 hover:bg-gray-200 dark:hover:bg-gray-600 cursor-grab" title="Kachel verschieben">
+                                    <i data-lucide="grip" class="w-4 h-4"></i>
+                                </button>
+                                <h3 class="font-semibold text-gray-900 dark:text-white">Ring Ereignisse</h3>
+                            </div>
+                            <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">Klingeln, Bewegung und weitere API-Historie</p>
+                        </div>
+                        <button id="refresh-ring-events-btn" class="px-3 py-1.5 bg-slate-700 text-white text-xs rounded hover:bg-slate-800">
+                            Aktualisieren
+                        </button>
+                    </div>
+                    <div id="ring-events-status" class="text-xs text-gray-500 dark:text-gray-400 mb-3">Ereignisse werden geladen...</div>
+                    <div id="ring-events-panel" class="rounded-xl border border-gray-200 dark:border-gray-600 overflow-hidden bg-gray-50 dark:bg-gray-700">
+                        <div class="p-4 text-sm text-gray-500 dark:text-gray-400">
+                            Noch keine Ring-Ereignisse geladen.
+                        </div>
+                    </div>
+                </div>
+            `;
+                    return;
+                }
+
+                const camId = cardId;
                 const cam = cameras[camId];
                 const streamType = (cam.type || 'rtsp').toLowerCase();
 
                 if (streamType === 'mjpeg') {
                     gridHtml += `
-                        <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 camera-card" data-cam-id="${camId}" data-cam-name="${cam.name}" data-cam-type="mjpeg">
-                            <h3 class="font-semibold text-gray-900 dark:text-white mb-2">${cam.name}</h3>
-                            <div class="aspect-video bg-gray-900 rounded overflow-hidden relative">
+                        <div class="bg-white/95 dark:bg-gray-800/95 rounded-2xl border border-gray-200/80 dark:border-gray-700 shadow-sm hover:shadow-lg hover:-translate-y-0.5 p-4 camera-card transition-transform transition-shadow duration-200" data-cam-id="${camId}" data-cam-name="${cam.name}" data-cam-type="mjpeg" data-card-id="${camId}">
+                            <div class="flex items-center gap-2 mb-2">
+                                <button class="camera-card-drag-handle p-1.5 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-500 hover:bg-gray-200 dark:hover:bg-gray-600 cursor-grab" title="Kachel verschieben">
+                                    <i data-lucide="grip" class="w-4 h-4"></i>
+                                </button>
+                                <h3 class="font-semibold text-gray-900 dark:text-white">${cam.name}</h3>
+                            </div>
+                            <div class="aspect-video bg-gray-900 rounded-xl overflow-hidden relative ring-1 ring-black/5">
                                 <img id="cam-image-${camId}" src="${cam.url}" alt="${cam.name}" class="w-full h-full object-cover"
                                      onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';">
                                 <div class="w-full h-full flex items-center justify-center text-white bg-gray-900" style="display:none;">
@@ -491,9 +612,14 @@
                     `;
                 } else if (streamType === 'ring') {
                     gridHtml += `
-                        <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 camera-card" data-cam-id="${camId}" data-cam-name="${cam.name}" data-cam-type="ring">
-                            <h3 class="font-semibold text-gray-900 dark:text-white mb-2">${cam.name}</h3>
-                            <div class="aspect-video bg-gray-900 rounded overflow-hidden relative">
+                        <div class="bg-white/95 dark:bg-gray-800/95 rounded-2xl border border-gray-200/80 dark:border-gray-700 shadow-sm hover:shadow-lg hover:-translate-y-0.5 p-4 camera-card transition-transform transition-shadow duration-200" data-cam-id="${camId}" data-cam-name="${cam.name}" data-cam-type="ring" data-card-id="${camId}">
+                            <div class="flex items-center gap-2 mb-2">
+                                <button class="camera-card-drag-handle p-1.5 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-500 hover:bg-gray-200 dark:hover:bg-gray-600 cursor-grab" title="Kachel verschieben">
+                                    <i data-lucide="grip" class="w-4 h-4"></i>
+                                </button>
+                                <h3 class="font-semibold text-gray-900 dark:text-white">${cam.name}</h3>
+                            </div>
+                            <div class="aspect-video bg-gray-900 rounded-xl overflow-hidden relative ring-1 ring-black/5">
                                 <video id="ring-video-${camId}" class="w-full h-full object-cover" muted autoplay playsinline style="display:none;"></video>
                                 <img id="cam-image-${camId}" src="" alt="${cam.name}" class="w-full h-full object-cover">
                                 <div id="ring-snapshot-ts-${camId}" class="absolute bottom-2 right-2 text-[11px] text-white bg-black/70 px-2 py-1 rounded pointer-events-none z-10 hidden">
@@ -522,9 +648,14 @@
                     `;
                 } else {
                     gridHtml += `
-                        <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4 camera-card" data-cam-id="${camId}" data-cam-name="${cam.name}" data-cam-type="rtsp">
-                            <h3 class="font-semibold text-gray-900 dark:text-white mb-2">${cam.name}</h3>
-                            <div class="aspect-video bg-gray-900 rounded overflow-hidden relative">
+                        <div class="bg-white/95 dark:bg-gray-800/95 rounded-2xl border border-gray-200/80 dark:border-gray-700 shadow-sm hover:shadow-lg hover:-translate-y-0.5 p-4 camera-card transition-transform transition-shadow duration-200" data-cam-id="${camId}" data-cam-name="${cam.name}" data-cam-type="rtsp" data-card-id="${camId}">
+                            <div class="flex items-center gap-2 mb-2">
+                                <button class="camera-card-drag-handle p-1.5 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-500 hover:bg-gray-200 dark:hover:bg-gray-600 cursor-grab" title="Kachel verschieben">
+                                    <i data-lucide="grip" class="w-4 h-4"></i>
+                                </button>
+                                <h3 class="font-semibold text-gray-900 dark:text-white">${cam.name}</h3>
+                            </div>
+                            <div class="aspect-video bg-gray-900 rounded-xl overflow-hidden relative ring-1 ring-black/5">
                                 <img id="cam-image-${camId}" src="" alt="${cam.name}" class="w-full h-full object-cover">
                                 <video id="hls-video-${camId}" class="w-full h-full object-cover" muted autoplay playsinline style="display:none;"></video>
                                 <div id="hls-loading-${camId}" class="absolute inset-0 flex items-center justify-center text-white bg-gray-900">
@@ -555,6 +686,8 @@
             if (typeof lucide !== 'undefined') {
                 lucide.createIcons();
             }
+
+            this._setupCameraGridDragAndDrop();
 
             rtspCams.forEach(camId => {
                 this._loadRtspSnapshot(camId, `cam-image-${camId}`, 4500);

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -268,12 +268,21 @@
         </div>
 
         <!-- Cameras Page -->
-        <div id="cameras-page" class="page page-container p-6">
-            <h1 class="text-2xl font-bold text-gray-900 dark:text-white mb-6 hidden md:block">Kameras</h1>
+        <div id="cameras-page" class="page page-container p-6 bg-gradient-to-b from-slate-50 via-white to-slate-100 dark:from-gray-950 dark:via-gray-900 dark:to-gray-950">
+            <div class="flex flex-col gap-2 mb-6 md:flex-row md:items-end md:justify-between">
+                <div>
+                    <h1 class="text-2xl font-bold tracking-tight text-gray-900 dark:text-white hidden md:block">Kameras</h1>
+                    <p class="text-sm text-gray-500 dark:text-gray-400">Live-Bilder, Ring-Ereignisse und Kamera-Layouts an einem Ort.</p>
+                </div>
+                <div class="inline-flex items-center gap-2 rounded-full border border-gray-200/80 bg-white/80 px-3 py-1.5 text-xs text-gray-500 shadow-sm backdrop-blur dark:border-gray-700 dark:bg-gray-800/80 dark:text-gray-300">
+                    <i data-lucide="grip" class="w-3.5 h-3.5"></i>
+                    <span>Kacheln lassen sich verschieben</span>
+                </div>
+            </div>
 
             <!-- RTSP Stream Konfiguration -->
-            <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6 mb-6">
-                <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">RTSP-Stream Konfiguration</h2>
+            <div class="bg-white/90 dark:bg-gray-800/90 rounded-2xl border border-gray-200/80 dark:border-gray-700 shadow-sm p-6 mb-6 backdrop-blur">
+                <h2 class="text-lg font-semibold tracking-tight text-gray-900 dark:text-white mb-4">RTSP-Stream Konfiguration</h2>
 
                 <div class="space-y-4">
                     <!-- Stream hinzufügen -->
@@ -317,24 +326,6 @@
                         <div id="ring-status" class="text-xs text-gray-500">Ring Status: unbekannt</div>
                     </div>
                     <div id="ring-import-result" class="hidden mt-2 p-3 bg-gray-50 dark:bg-gray-700 rounded-lg text-sm"></div>
-
-                    <div class="mt-4 pt-4 border-t border-gray-200 dark:border-gray-600 space-y-3">
-                        <div class="flex items-center justify-between gap-3">
-                            <div>
-                                <h3 class="text-sm font-semibold text-gray-700 dark:text-gray-300">Ring Ereignisse</h3>
-                                <p class="text-xs text-gray-500 dark:text-gray-400">API-Historie mit Datum, Uhrzeit und Trigger-Ereignis</p>
-                            </div>
-                            <button id="refresh-ring-events-btn" class="px-3 py-2 bg-slate-700 text-white text-xs rounded-lg hover:bg-slate-800">
-                                Aktualisieren
-                            </button>
-                        </div>
-                        <div id="ring-events-status" class="text-xs text-gray-500 dark:text-gray-400">Ereignisse werden geladen...</div>
-                        <div id="ring-events-panel" class="rounded-lg border border-gray-200 dark:border-gray-600 overflow-hidden">
-                            <div class="p-4 text-sm text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-700">
-                                Noch keine Ring-Ereignisse geladen.
-                            </div>
-                        </div>
-                    </div>
 
                     <!-- Netzwerk-Scan + Kamera-Diagnose -->
                     <div class="mt-4 pt-4 border-t border-gray-200 dark:border-gray-600">
@@ -401,18 +392,21 @@
             </div>
 
             <!-- Grid-Layout-Toggle -->
-            <div class="flex items-center justify-between mb-4">
-                <h2 class="text-lg font-semibold text-gray-900 dark:text-white">Live-Streams</h2>
-                <div class="flex items-center space-x-2">
+            <div class="flex flex-col gap-3 mb-4 md:flex-row md:items-center md:justify-between">
+                <div>
+                    <h2 class="text-lg font-semibold tracking-tight text-gray-900 dark:text-white">Live-Streams</h2>
+                    <p class="text-xs text-gray-500 dark:text-gray-400">Ordne deine Kamera-Kacheln so an, wie du sie wirklich brauchst.</p>
+                </div>
+                <div class="flex items-center space-x-2 rounded-full border border-gray-200/80 dark:border-gray-700 bg-white/80 dark:bg-gray-800/80 px-3 py-2 shadow-sm">
                     <span class="text-sm text-gray-500 dark:text-gray-400 mr-2">Spalten:</span>
-                    <button data-grid-cols="1" class="grid-layout-btn px-3 py-1 text-sm rounded border border-gray-300 dark:border-gray-600 hover:bg-blue-500 hover:text-white hover:border-blue-500 transition">1</button>
-                    <button data-grid-cols="2" class="grid-layout-btn px-3 py-1 text-sm rounded border border-gray-300 dark:border-gray-600 hover:bg-blue-500 hover:text-white hover:border-blue-500 transition bg-blue-500 text-white border-blue-500">2</button>
-                    <button data-grid-cols="3" class="grid-layout-btn px-3 py-1 text-sm rounded border border-gray-300 dark:border-gray-600 hover:bg-blue-500 hover:text-white hover:border-blue-500 transition">3</button>
+                    <button data-grid-cols="1" class="grid-layout-btn px-3 py-1 text-sm rounded-full border border-gray-300 dark:border-gray-600 hover:bg-blue-500 hover:text-white hover:border-blue-500 transition">1</button>
+                    <button data-grid-cols="2" class="grid-layout-btn px-3 py-1 text-sm rounded-full border border-gray-300 dark:border-gray-600 hover:bg-blue-500 hover:text-white hover:border-blue-500 transition bg-blue-500 text-white border-blue-500">2</button>
+                    <button data-grid-cols="3" class="grid-layout-btn px-3 py-1 text-sm rounded-full border border-gray-300 dark:border-gray-600 hover:bg-blue-500 hover:text-white hover:border-blue-500 transition">3</button>
                 </div>
             </div>
 
             <!-- Live-Streams -->
-            <div id="cameras-grid" class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div id="cameras-grid" class="grid grid-cols-1 md:grid-cols-2 gap-5">
                 <p class="text-gray-500">Kameras werden nach Konfiguration hier angezeigt...</p>
             </div>
         </div>
@@ -1584,9 +1578,9 @@
          ================================================================ -->
     <script defer src="/static/js/socket_handler.js"></script>
     <script defer src="/static/js/variable-manager.js"></script> <!-- ⭐ v4.6.0 -->
-    <script defer src="/static/js/ring-ui.js?v=20260323-ring-ui-split"></script>
-    <script defer src="/static/js/camera-page-ui.js?v=20260323-camera-ui-split"></script>
-    <script defer src="/static/js/app.js?v=20260323-camera-ui-split"></script>
+    <script defer src="/static/js/ring-ui.js?v=20260323-camera-ui-modern"></script>
+    <script defer src="/static/js/camera-page-ui.js?v=20260323-camera-ui-modern"></script>
+    <script defer src="/static/js/app.js?v=20260323-camera-ui-modern"></script>
 
     <!-- Lucide Icons initialisieren -->
     <script>


### PR DESCRIPTION
## Summary
- polish the camera page layout with a more compact, modern header and card styling
- move Ring events into the camera tile area and make all camera tiles reorderable
- persist camera tile order locally and bump frontend asset versions for cache busting

## Testing
- node --check web/static/js/app.js
- node --check web/static/js/camera-page-ui.js
- manual browser verification on the cameras page
